### PR TITLE
Add Reader Mode browser smoke tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.7.1",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@playwright/test": "^1.60.0",
 				"@wordpress/api-fetch": "^7.45.0",
 				"@wordpress/block-editor": "^15.18.0",
 				"@wordpress/blocks": "^15.18.0",
@@ -4460,7 +4461,6 @@
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
 			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"playwright": "1.60.0"
 			},
@@ -17796,7 +17796,6 @@
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
 			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"playwright-core": "1.60.0"
 			},
@@ -17815,7 +17814,6 @@
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
 			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -17833,7 +17831,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"build": "wp-scripts build",
 		"start": "wp-scripts start",
+		"test:browser": "playwright test",
 		"lint:js": "wp-scripts lint-js assets/src/js",
 		"lint:css": "wp-scripts lint-style assets/src/css",
 		"format": "wp-scripts format assets/src webpack.config.js",
@@ -26,6 +27,7 @@
 	},
 	"homepage": "https://github.com/mehul0810/wp-distraction-free-view#readme",
 	"devDependencies": {
+		"@playwright/test": "^1.60.0",
 		"@wordpress/api-fetch": "^7.45.0",
 		"@wordpress/block-editor": "^15.18.0",
 		"@wordpress/blocks": "^15.18.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,21 @@
+const { defineConfig, devices } = require( '@playwright/test' );
+
+module.exports = defineConfig( {
+	testDir: './tests/browser',
+	timeout: 30000,
+	expect: {
+		timeout: 5000,
+	},
+	fullyParallel: true,
+	reporter: process.env.CI ? 'github' : 'list',
+	use: {
+		baseURL: process.env.WPDFV_SMOKE_BASE_URL || 'http://127.0.0.1:8889',
+		trace: 'retain-on-failure',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+	],
+} );

--- a/tests/browser/reader-mode.spec.js
+++ b/tests/browser/reader-mode.spec.js
@@ -1,0 +1,176 @@
+const { expect, test } = require( '@playwright/test' );
+
+const hasSmokeBaseUrl = Boolean( process.env.WPDFV_SMOKE_BASE_URL );
+const readerUrl =
+	process.env.WPDFV_SMOKE_READER_PATH || process.env.WPDFV_SMOKE_BASE_URL;
+const toggleSelector = '.wpdfv-fullscreen-btn.wpdfv-reader-toggle';
+const modalSelector = '.wpdfv-reader-modal';
+const storageKey = 'wpdfv_reader_preferences';
+
+test.describe( 'Reader Mode smoke', () => {
+	test.skip(
+		! hasSmokeBaseUrl,
+		'Set WPDFV_SMOKE_BASE_URL to a WordPress page with WP Distraction Free View active.'
+	);
+
+	test.beforeEach( async ( { page } ) => {
+		await page.goto( readerUrl );
+		await expect( page.locator( toggleSelector ).first() ).toBeVisible();
+	} );
+
+	test( 'opens and closes from the Reader Mode toggle', async ( { page } ) => {
+		await openReader( page );
+		await expect( page.locator( modalSelector ) ).toBeVisible();
+		await expect( page.locator( 'html' ) ).toHaveClass(
+			/wpdfv-reader-mode-active/
+		);
+		await expect( page.locator( 'body' ) ).toHaveClass(
+			/wpdfv-reader-mode-active/
+		);
+
+		await page
+			.getByRole( 'button', { name: /exit reader mode|close/i } )
+			.click();
+
+		await expect( page.locator( modalSelector ) ).toBeHidden();
+		await expect( page.locator( 'html' ) ).not.toHaveClass(
+			/wpdfv-reader-mode-active/
+		);
+		await expect( page.locator( 'body' ) ).not.toHaveClass(
+			/wpdfv-reader-mode-active/
+		);
+	} );
+
+	test( 'auto-opens when reader-mode query parameter is enabled', async ( {
+		page,
+	} ) => {
+		await page.goto( withReaderModeQuery( readerUrl ) );
+
+		await expect( page.locator( modalSelector ) ).toBeVisible();
+		await expect( page.locator( 'html' ) ).toHaveClass(
+			/wpdfv-reader-mode-active/
+		);
+	} );
+
+	test( 'persists font size, theme, and width preferences', async ( {
+		page,
+	} ) => {
+		await page.addInitScript(
+			( key ) => window.localStorage.removeItem( key ),
+			storageKey
+		);
+		await page.goto( readerUrl );
+		await openReader( page );
+
+		await page.getByRole( 'button', { name: 'Reader settings' } ).click();
+		await page
+			.locator( '.wpdfv-reader-settings-panel' )
+			.getByRole( 'button', { name: 'Large' } )
+			.click();
+		await page
+			.locator( '.wpdfv-reader-settings-panel' )
+			.getByRole( 'button', { name: 'Dark' } )
+			.click();
+		await page
+			.locator( '.wpdfv-reader-settings-panel' )
+			.getByRole( 'button', { name: 'Wide' } )
+			.click();
+
+		await expect( page.locator( modalSelector ) ).toHaveClass(
+			/wpdfv-reader-modal--font-large/
+		);
+		await expect( page.locator( modalSelector ) ).toHaveClass(
+			/wpdfv-reader-modal--theme-dark/
+		);
+		await expect( page.locator( modalSelector ) ).toHaveClass(
+			/wpdfv-reader-modal--width-wide/
+		);
+
+		await expect
+			.poll( () =>
+				page.evaluate( ( key ) => {
+					const stored = window.localStorage.getItem( key );
+					return stored ? JSON.parse( stored ) : null;
+				}, storageKey )
+			)
+			.toEqual( {
+				fontSize: 'large',
+				theme: 'dark',
+				width: 'wide',
+			} );
+
+		await page.reload();
+		await openReader( page );
+
+		await expect( page.locator( modalSelector ) ).toHaveClass(
+			/wpdfv-reader-modal--font-large/
+		);
+		await expect( page.locator( modalSelector ) ).toHaveClass(
+			/wpdfv-reader-modal--theme-dark/
+		);
+		await expect( page.locator( modalSelector ) ).toHaveClass(
+			/wpdfv-reader-modal--width-wide/
+		);
+	} );
+
+	test( 'shows reading progress only when enabled by frontend settings', async ( {
+		page,
+	} ) => {
+		await openReader( page );
+
+		const progressEnabled = await page.evaluate(
+			() => window.wpdfvReaderMode?.readingProgressEnabled !== false
+		);
+		const progress = page.locator( '.wpdfv-reading-progress' );
+
+		if ( progressEnabled ) {
+			await expect( progress ).toBeVisible();
+			return;
+		}
+
+		await expect( progress ).toHaveCount( 0 );
+	} );
+
+	test( 'keeps header actions usable in a mobile viewport', async ( {
+		page,
+	} ) => {
+		await page.setViewportSize( { width: 390, height: 844 } );
+		await page.goto( readerUrl );
+		await openReader( page );
+
+		const header = page.locator( '.components-modal__header' );
+		const actions = page.locator( '.wpdfv-reader-header-actions' );
+
+		await expect( header ).toBeVisible();
+		await expect( actions ).toBeVisible();
+
+		const headerBox = await header.boundingBox();
+		const actionsBox = await actions.boundingBox();
+
+		expect( headerBox ).not.toBeNull();
+		expect( actionsBox ).not.toBeNull();
+		expect( actionsBox.x + actionsBox.width ).toBeLessThanOrEqual(
+			headerBox.x + headerBox.width + 1
+		);
+		expect( actionsBox.y + actionsBox.height ).toBeLessThanOrEqual(
+			headerBox.y + headerBox.height + 1
+		);
+	} );
+} );
+
+async function openReader( page ) {
+	await page.locator( toggleSelector ).first().click();
+	await expect( page.locator( modalSelector ) ).toBeVisible();
+	await expect(
+		page.locator( '.wpdfv-reader-loading, .wpdfv-reader-content' )
+	).toBeVisible();
+}
+
+function withReaderModeQuery( path ) {
+	const url = new URL( path, 'http://example.com' );
+	url.searchParams.set( 'reader-mode', '1' );
+
+	return path.startsWith( 'http' )
+		? url.toString()
+		: `${ url.pathname }${ url.search }${ url.hash }`;
+}


### PR DESCRIPTION
## Summary
- Add Playwright browser smoke test tooling for Reader Mode
- Cover modal open/close, query-param auto-open, localStorage preferences, reading progress, and mobile header/action layout
- Gate live browser execution behind WPDFV_SMOKE_BASE_URL so CI/local runs skip cleanly until a WordPress smoke page is provided

## Validation
- npm run lint:js
- npm run lint:css
- npm run build
- composer lint
- composer test: 24 tests, 102 assertions
- npm run test:browser: passed harness check with 5 skipped because WPDFV_SMOKE_BASE_URL was not set

## Notes
- Relates to #43
- No release, merge, issue closure, or milestone changes performed
- Live WordPress smoke execution still needs a reachable page URL with WP Distraction Free View active via WPDFV_SMOKE_BASE_URL