### PR TITLE
Ensure shortcode Reader Mode assets enqueue

### DIFF
--- a/src/Includes/Shortcodes/Main.php
+++ b/src/Includes/Shortcodes/Main.php
@@ -11,6 +11,7 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use WPDFV\Includes\Actions;
 use WPDFV\Includes\Helpers;
 use WPDFV\Includes\Reader;
 use WPDFV\Includes\Templates;
@@ -62,6 +63,8 @@ class Main {
 		if ( ! $post_type || ! Reader::is_post_type_enabled( $post_type ) ) {
 			return '';
 		}
+
+		Actions::enqueue_frontend_assets();
 
 		return Helpers::display_read_mode_button( $post_id );
 	}

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -9,6 +9,7 @@ namespace WPDFV\Tests;
 
 use PHPUnit\Framework\TestCase;
 use WPDFV\Admin\Upgrades;
+use WPDFV\Includes\Actions;
 use WPDFV\Includes\Blocks;
 use WPDFV\Includes\Helpers;
 use WPDFV\Includes\Reader;
@@ -475,6 +476,78 @@ class ReaderTest extends TestCase {
 		$this->assertStringContainsString( 'data-post-id="42"', $markup );
 		$this->assertContains( 'wpdfv-core', $GLOBALS['wpdfv_test_enqueued']['scripts'] );
 		$this->assertArrayHasKey( 'wpdfv-core', $GLOBALS['wpdfv_test_enqueued']['inline'] );
+	}
+
+	/**
+	 * Manual shortcode output should enqueue the shared frontend assets.
+	 *
+	 * @return void
+	 */
+	public function test_shortcode_uses_shared_frontend_assets() {
+		\update_option(
+			'wpdfv_settings',
+			array_merge(
+				Reader::get_default_settings(),
+				[
+					'where_to_display' => [ 'post' ],
+				]
+			),
+			false
+		);
+
+		$post            = new \WP_Post();
+		$post->ID        = 42;
+		$post->post_type = 'post';
+
+		$GLOBALS['wpdfv_test_posts'][42] = $post;
+
+		$shortcode = new Main();
+		$markup    = $shortcode->render_shortcode( [ 'post_id' => 42 ] );
+
+		$this->assertStringContainsString( 'data-post-id="42"', $markup );
+		$this->assertContains( 'wpdfv-core', $GLOBALS['wpdfv_test_enqueued']['scripts'] );
+		$this->assertArrayHasKey( 'wpdfv-core', $GLOBALS['wpdfv_test_enqueued']['inline'] );
+		$this->assertCount( 1, $GLOBALS['wpdfv_test_enqueued']['inline']['wpdfv-core'] );
+	}
+
+	/**
+	 * Multiple reader placements should not duplicate inline runtime settings.
+	 *
+	 * @return void
+	 */
+	public function test_reader_assets_add_inline_settings_once_for_multiple_placements() {
+		\update_option(
+			'wpdfv_settings',
+			array_merge(
+				Reader::get_default_settings(),
+				[
+					'where_to_display' => [ 'post' ],
+				]
+			),
+			false
+		);
+
+		$post            = new \WP_Post();
+		$post->ID        = 42;
+		$post->post_type = 'post';
+
+		$GLOBALS['wpdfv_test_posts'][42] = $post;
+
+		$block = (object) [
+			'context' => [
+				'postId'   => 42,
+				'postType' => 'post',
+			],
+		];
+
+		$blocks    = new Blocks();
+		$shortcode = new Main();
+
+		$blocks->render_reader_button( [], '', $block );
+		$shortcode->render_shortcode( [ 'post_id' => 42 ] );
+		Actions::enqueue_frontend_assets();
+
+		$this->assertCount( 1, $GLOBALS['wpdfv_test_enqueued']['inline']['wpdfv-core'] );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -71,6 +71,12 @@ function wpdfv_tests_reset_state() {
 	$GLOBALS['wpdfv_test_posts']          = [];
 	$GLOBALS['wpdfv_test_shortcodes']     = [];
 	$_GET                                 = [];
+
+	if ( class_exists( '\WPDFV\Includes\Actions' ) ) {
+		$frontend_settings_added = new ReflectionProperty( '\WPDFV\Includes\Actions', 'frontend_settings_added' );
+		$frontend_settings_added->setAccessible( true );
+		$frontend_settings_added->setValue( null, false );
+	}
 }
 
 function plugin_basename( $file ) {


### PR DESCRIPTION
## Summary
- Enqueue the shared Reader Mode frontend assets when the shortcode confirms it will render a toggle.
- Add PHPUnit coverage for shortcode-triggered asset enqueueing.
- Reset the frontend inline-settings guard between tests and verify mixed block/shortcode/direct enqueue paths only add inline settings once.

## Validation
- php -l on touched PHP files
- composer test -- --filter reader asset placement coverage
- composer test
- composer lint -- src/Includes/Shortcodes/Main.php tests/bootstrap.php tests/ReaderTest.php
- git diff --check

Relates to #42