### PR TITLE
Ensure shortcode Reader Mode assets enqueue

### DIFF
--- a/src/Includes/Shortcodes/Main.php
+++ b/src/Includes/Shortcodes/Main.php
@@ -11,6 +11,7 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use WPDFV\Includes\Actions;
 use WPDFV\Includes\Helpers;
 use WPDFV\Includes\Reader;
 use WPDFV\Includes\Templates;
@@ -62,6 +63,8 @@ class Main {
 		if ( ! $post_type || ! Reader::is_post_type_enabled( $post_type ) ) {
 			return '';
 		}
+
+		Actions::enqueue_frontend_assets();
 
 		return Helpers::display_read_mode_button( $post_id );
 	}

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -511,6 +511,78 @@ class ReaderTest extends TestCase {
 	}
 
 	/**
+	 * Manual shortcode output should enqueue the shared frontend assets.
+	 *
+	 * @return void
+	 */
+	public function test_shortcode_uses_shared_frontend_assets() {
+		\update_option(
+			'wpdfv_settings',
+			array_merge(
+				Reader::get_default_settings(),
+				[
+					'where_to_display' => [ 'post' ],
+				]
+			),
+			false
+		);
+
+		$post            = new \WP_Post();
+		$post->ID        = 42;
+		$post->post_type = 'post';
+
+		$GLOBALS['wpdfv_test_posts'][42] = $post;
+
+		$shortcode = new Main();
+		$markup    = $shortcode->render_shortcode( [ 'post_id' => 42 ] );
+
+		$this->assertStringContainsString( 'data-post-id="42"', $markup );
+		$this->assertContains( 'wpdfv-core', $GLOBALS['wpdfv_test_enqueued']['scripts'] );
+		$this->assertArrayHasKey( 'wpdfv-core', $GLOBALS['wpdfv_test_enqueued']['inline'] );
+		$this->assertCount( 1, $GLOBALS['wpdfv_test_enqueued']['inline']['wpdfv-core'] );
+	}
+
+	/**
+	 * Multiple reader placements should not duplicate inline runtime settings.
+	 *
+	 * @return void
+	 */
+	public function test_reader_assets_add_inline_settings_once_for_multiple_placements() {
+		\update_option(
+			'wpdfv_settings',
+			array_merge(
+				Reader::get_default_settings(),
+				[
+					'where_to_display' => [ 'post' ],
+				]
+			),
+			false
+		);
+
+		$post            = new \WP_Post();
+		$post->ID        = 42;
+		$post->post_type = 'post';
+
+		$GLOBALS['wpdfv_test_posts'][42] = $post;
+
+		$block = (object) [
+			'context' => [
+				'postId'   => 42,
+				'postType' => 'post',
+			],
+		];
+
+		$blocks    = new Blocks();
+		$shortcode = new Main();
+
+		$blocks->render_reader_button( [], '', $block );
+		$shortcode->render_shortcode( [ 'post_id' => 42 ] );
+		Actions::enqueue_frontend_assets();
+
+		$this->assertCount( 1, $GLOBALS['wpdfv_test_enqueued']['inline']['wpdfv-core'] );
+	}
+
+	/**
 	 * Built block editor assets must declare every WordPress package they use.
 	 *
 	 * @return void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -71,6 +71,12 @@ function wpdfv_tests_reset_state() {
 	$GLOBALS['wpdfv_test_posts']          = [];
 	$GLOBALS['wpdfv_test_shortcodes']     = [];
 	$_GET                                 = [];
+
+	if ( class_exists( '\WPDFV\Includes\Actions' ) ) {
+		$frontend_settings_added = new ReflectionProperty( '\WPDFV\Includes\Actions', 'frontend_settings_added' );
+		$frontend_settings_added->setAccessible( true );
+		$frontend_settings_added->setValue( null, false );
+	}
 }
 
 function plugin_basename( $file ) {


### PR DESCRIPTION
## Summary
- Enqueue the shared Reader Mode frontend assets when the shortcode confirms it will render a toggle.
- Add PHPUnit coverage for shortcode-triggered asset enqueueing.
- Reset the frontend inline-settings guard between tests and verify mixed block/shortcode/direct enqueue paths only add inline settings once.

## Branch recovery note
- Replaces #73, which was closed after the incorrect release/3 branch was removed.
- Correct milestone base is release/1.8.0.

## Validation
- php -l src/Includes/Shortcodes/Main.php
- php -l tests/ReaderTest.php
- composer test -- --filter 'test_shortcode_uses_shared_frontend_assets|test_reader_assets_add_inline_settings_once_for_multiple_placements'
- git diff --check origin/release/1.8.0..HEAD

Relates to #42