### PR TITLE
Add Reader Mode setup and troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Use the **WP Distraction Free View / Reader Mode Toggle** block in posts, pages,
 
 The block is dynamic and uses the current post context, so it opens the correct post when placed in single templates or inside Query Loop templates.
 
+## Setup and Troubleshooting
+
+For step-by-step placement guidance, URL activation, preference privacy notes, and shortcode/embed troubleshooting, see [Reader Mode Setup and Troubleshooting](docs/reader-mode-setup.md).
+
 ## Modal Templates
 
 The Reader Mode content is rendered through block-based templates. The plugin registers a default Reader Mode layout and a `WP Distraction Free View` pattern category for block themes.

--- a/docs/reader-mode-setup.md
+++ b/docs/reader-mode-setup.md
@@ -1,0 +1,82 @@
+# Reader Mode Setup and Troubleshooting
+
+This guide covers the public Reader Mode experience in WP Distraction Free View: where Reader Mode is available, how visitors open it, and what to check when a toggle or embedded content does not behave as expected.
+
+## Quick Setup
+
+1. Activate WP Distraction Free View.
+2. Go to **Settings > Reader Mode**.
+3. Open the **Configure** tab.
+4. Enable Reader Mode for the public post types that should support focused reading.
+5. Choose a placement:
+   - Use **manual only** when you want to place the toggle with the block or shortcode.
+   - Use **before content**, **after content**, or **floating** when the plugin should insert the toggle automatically.
+6. Save settings.
+7. Visit an enabled single post, page, or custom post type and open Reader Mode from the toggle.
+
+Reader Mode is disabled for new installs until you enable post types or place a manual toggle.
+
+## Block Placement
+
+Use the **WP Distraction Free View / Reader Mode Toggle** block when editing posts, pages, public custom post types, single templates, or Query Loop templates.
+
+The block is dynamic. In a single template or Query Loop, it uses the current post context so each toggle opens Reader Mode for the correct post.
+
+## Shortcode Usage
+
+Use the shortcode when a block is not the right fit:
+
+```text
+[wpdfv]
+```
+
+The shortcode can be placed in post content, widget areas, template parts, or other shortcode-aware surfaces. Reader Mode assets load when the shortcode renders a valid toggle for an enabled post type.
+
+## Automatic Placement
+
+Automatic placement inserts the Reader Mode toggle on supported single content without adding a block or shortcode manually.
+
+Use automatic placement when you want the same entry point across enabled post types. Use manual placement when a theme, template, or editorial workflow needs precise control over where the toggle appears.
+
+## Supported Post Types
+
+Reader Mode can be enabled for posts, pages, and selected public custom post types. If a toggle does not appear, confirm that the current content type is enabled in **Settings > Reader Mode > Configure**.
+
+Reader Mode is intended for single content views. Archive pages, search results, unsupported post types, and unrelated admin screens should not load the frontend Reader Mode assets.
+
+## URL Activation
+
+Reader Mode can open directly from a URL on enabled single content:
+
+```text
+https://example.com/my-post/?reader-mode=1
+```
+
+Use this for direct links to a focused reading view. The URL parameter uses the same Reader Mode experience as the toggle.
+
+## Reader Preferences and Privacy
+
+Visitors can adjust font size, theme, and content width when preference controls are enabled. These preferences are stored in the visitor browser with `localStorage`.
+
+WP Distraction Free View does not store Reader Mode preference choices on the server.
+
+## Shortcode and Embed Troubleshooting
+
+Version 1.7.1 strips complete `script`, `style`, and `noscript` blocks from Reader Mode content before final sanitization. This prevents common shortcode embed configuration from appearing as raw text inside the Reader Mode view.
+
+If embedded content still looks wrong:
+
+1. Confirm the original post content renders correctly outside Reader Mode.
+2. Confirm the plugin, theme, and shortcode provider are updated.
+3. Check whether the shortcode provider requires inline scripts that only run in the original theme layout.
+4. Test whether the issue appears with a default WordPress theme.
+5. Share the shortcode provider name, WordPress version, theme, and a minimal example in the support channel.
+
+Do not paste private embed keys, tokens, or account identifiers into public support threads.
+
+## Support Boundaries
+
+Use the [WordPress.org support forum](https://wordpress.org/support/plugin/wp-distraction-free-view/) for user support, setup questions, and compatibility reports.
+
+Use [GitHub issues](https://github.com/mehul0810/wp-distraction-free-view/issues) for reproducible development issues, release-train work, and code-level reports.
+

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,10 @@ Reader Mode can also open from the URL on enabled single content:
 
 `https://example.com/my-post/?reader-mode=1`
 
+Setup and troubleshooting guide:
+
+https://github.com/mehul0810/wp-distraction-free-view/blob/release/1.8.0/docs/reader-mode-setup.md
+
 = Template Customization =
 
 The Reader Mode content is rendered through block-based templates. The plugin registers a default Reader Mode layout and a `WP Distraction Free View` pattern category for block themes.


### PR DESCRIPTION
## Summary
- Add a canonical repository docs page for Reader Mode setup and troubleshooting.
- Link the guide from README.md and the WordPress.org readme without expanding the plugin-page copy.
- Document block, shortcode, automatic placement, supported post types, URL activation, localStorage preference behavior, shortcode/embed troubleshooting, and support boundaries.

## Validation
- git diff --check
- UTF-8/readability check for README.md, readme.txt, and docs/reader-mode-setup.md
- Existing release-branch validation after prior merges: composer test passed with 28 tests / 116 assertions; npm build, npm run lint:js, and npm run lint:css pass with Node 24.15.0.

Relates to #66