### PR TITLE
Add WordPress integration test layer

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,6 +12,7 @@
 /release
 
 /tests
+/bin
 /node_modules
 /assets/src
 /vendor/bin
@@ -50,6 +51,7 @@ package.json
 package-lock.json
 phpunit.xml
 phpunit.xml.dist
+phpunit.integration.xml.dist
 CHANGELOG.md
 README.md
 DESIGN.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,52 @@ jobs:
       - name: Build assets
         run: npm run build
 
+  integration-tests:
+    name: WordPress integration tests
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_DATABASE: wordpress_test
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=root"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Install WordPress test suite
+        run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest true
+
+      - name: PHPUnit integration tests
+        env:
+          WP_TESTS_DIR: /tmp/wordpress-tests-lib
+        run: composer test:integration
+
+      - name: PHPUnit integration tests with multisite
+        env:
+          WP_TESTS_DIR: /tmp/wordpress-tests-lib
+          WP_MULTISITE: 1
+        run: composer test:integration
+
   production-package:
     name: Production package and Plugin Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-progress
 
+      - name: Use WordPress-compatible PHPUnit
+        run: composer require --dev phpunit/phpunit:^9.6 --with-all-dependencies --no-progress
+
       - name: Install WordPress test suite
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest true
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ npm run lint:css
 npm run build
 ```
 
+Run the WordPress integration suite against the WordPress test library:
+
+```bash
+bash bin/install-wp-tests.sh wordpress_test root root localhost latest
+WP_TESTS_DIR=/tmp/wordpress-tests-lib composer test:integration
+WP_TESTS_DIR=/tmp/wordpress-tests-lib WP_MULTISITE=1 composer test:integration
+```
+
+The integration suite is intentionally separate from `composer test`. It boots real WordPress APIs for REST routing, block registration/rendering, options, migrations, and multisite activation coverage.
+
 ## Release Workflow
 
 The WordPress.org release workflow generates `wp-distraction-free-view.zip` through the 10up deploy action and uploads that ZIP to the matching GitHub release. Uploads use `gh release upload --clobber`, so rerunning a release or prerelease workflow replaces the existing ZIP asset instead of failing when the asset name already exists.

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -54,14 +54,28 @@ install_test_suite() {
 		branch="tags/${WP_VERSION}"
 	fi
 
-	if ! command -v svn >/dev/null 2>&1; then
-		echo "svn is required to install the full WordPress PHPUnit test suite." >&2
+	if command -v svn >/dev/null 2>&1; then
+		mkdir -p "$WP_TESTS_DIR"
+		svn export --quiet "https://develop.svn.wordpress.org/${branch}/tests/phpunit/includes" "${WP_TESTS_DIR}/includes"
+		svn export --quiet "https://develop.svn.wordpress.org/${branch}/tests/phpunit/data" "${WP_TESTS_DIR}/data"
+		return
+	fi
+
+	if [ "$WP_VERSION" != "latest" ]; then
+		echo "svn is required to install versioned WordPress PHPUnit test suites." >&2
 		exit 1
 	fi
 
+	local develop_dir="${TMPDIR}/wordpress-develop"
+	local archive="${TMPDIR}/wordpress-develop.tar.gz"
+
+	download https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.tar.gz "$archive"
+	rm -rf "$develop_dir"
 	mkdir -p "$WP_TESTS_DIR"
-	svn export --quiet "https://develop.svn.wordpress.org/${branch}/tests/phpunit/includes" "${WP_TESTS_DIR}/includes"
-	svn export --quiet "https://develop.svn.wordpress.org/${branch}/tests/phpunit/data" "${WP_TESTS_DIR}/data"
+	mkdir -p "$develop_dir"
+	tar --strip-components=1 -xzf "$archive" -C "$develop_dir"
+	cp -R "${develop_dir}/tests/phpunit/includes" "${WP_TESTS_DIR}/includes"
+	cp -R "${develop_dir}/tests/phpunit/data" "${WP_TESTS_DIR}/data"
 }
 
 install_config() {

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DB_NAME=${1-wordpress_test}
+DB_USER=${2-root}
+DB_PASS=${3-root}
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+WP_TESTS_DIR=${WP_TESTS_DIR-${TMPDIR}/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-${TMPDIR}/wordpress}
+
+download() {
+	local url=$1
+	local target=$2
+
+	if command -v curl >/dev/null 2>&1; then
+		curl -sL "$url" -o "$target"
+	elif command -v wget >/dev/null 2>&1; then
+		wget -nv -O "$target" "$url"
+	else
+		echo "curl or wget is required to download WordPress test files." >&2
+		exit 1
+	fi
+}
+
+download_wordpress() {
+	if [ -d "$WP_CORE_DIR" ]; then
+		return
+	fi
+
+	mkdir -p "$WP_CORE_DIR"
+
+	local archive="${TMPDIR}/wordpress.tar.gz"
+	if [ "$WP_VERSION" = "latest" ]; then
+		download https://wordpress.org/latest.tar.gz "$archive"
+	else
+		download "https://wordpress.org/wordpress-${WP_VERSION}.tar.gz" "$archive"
+	fi
+
+	tar --strip-components=1 -xzf "$archive" -C "$WP_CORE_DIR"
+}
+
+install_test_suite() {
+	if [ -d "$WP_TESTS_DIR" ]; then
+		return
+	fi
+
+	local branch="trunk"
+	if [ "$WP_VERSION" != "latest" ]; then
+		branch="tags/${WP_VERSION}"
+	fi
+
+	if ! command -v svn >/dev/null 2>&1; then
+		echo "svn is required to install the full WordPress PHPUnit test suite." >&2
+		exit 1
+	fi
+
+	mkdir -p "$WP_TESTS_DIR"
+	svn export --quiet "https://develop.svn.wordpress.org/${branch}/tests/phpunit/includes" "${WP_TESTS_DIR}/includes"
+	svn export --quiet "https://develop.svn.wordpress.org/${branch}/tests/phpunit/data" "${WP_TESTS_DIR}/data"
+}
+
+install_config() {
+	local config="${WP_TESTS_DIR}/wp-tests-config.php"
+
+	if [ -f "$config" ]; then
+		return
+	fi
+
+	local branch="trunk"
+	if [ "$WP_VERSION" != "latest" ]; then
+		branch="tags/${WP_VERSION}"
+	fi
+
+	download "https://develop.svn.wordpress.org/${branch}/wp-tests-config-sample.php" "$config"
+	sed -i.bak "s:dirname( __FILE__ ) . '/src/':'${WP_CORE_DIR}/':" "$config"
+	sed -i.bak "s/youremptytestdbnamehere/${DB_NAME}/" "$config"
+	sed -i.bak "s/yourusernamehere/${DB_USER}/" "$config"
+	sed -i.bak "s/yourpasswordhere/${DB_PASS}/" "$config"
+	sed -i.bak "s|localhost|${DB_HOST}|" "$config"
+	rm -f "${config}.bak"
+}
+
+create_database() {
+	if [ "$SKIP_DB_CREATE" = "true" ]; then
+		return
+	fi
+
+	mysqladmin create "$DB_NAME" --user="$DB_USER" --password="$DB_PASS" --host="$DB_HOST" 2>/dev/null || true
+}
+
+download_wordpress
+install_test_suite
+install_config
+create_database
+
+echo "WordPress tests installed in ${WP_TESTS_DIR}"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpunit": "^11.5",
 		"squizlabs/php_codesniffer": "^3.13",
-		"wp-coding-standards/wpcs": "^3.2"
+		"wp-coding-standards/wpcs": "^3.2",
+		"yoast/phpunit-polyfills": "^4.0"
 	},
 	"config": {
 		"allow-plugins": {
@@ -26,7 +27,8 @@
 	"scripts": {
 		"lint": "phpcs --standard=phpcs.ruleset.xml --extensions=php .",
 		"format": "phpcbf --standard=phpcs.ruleset.xml --extensions=php .",
-		"test": "phpunit"
+		"test": "phpunit",
+		"test:integration": "phpunit -c phpunit.integration.xml.dist"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bef222bcc20771bf6e55ccd625a7d09b",
+    "content-hash": "2d802f1152422db9a57e219dc19d5fb7",
     "packages": [],
     "packages-dev": [
         {
@@ -2416,6 +2416,69 @@
                 }
             ],
             "time": "2025-11-25T12:08:04+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.integration.xml.dist
+++ b/phpunit.integration.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/integration/bootstrap.php" colors="true">
+	<testsuites>
+		<testsuite name="WP Distraction Free View Integration">
+			<directory>tests/integration</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 	<testsuites>
 		<testsuite name="WP Distraction Free View">
 			<directory>tests</directory>
+			<exclude>tests/integration</exclude>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/integration/ReaderIntegrationTest.php
+++ b/tests/integration/ReaderIntegrationTest.php
@@ -7,9 +7,9 @@
 
 namespace WPDFV\Tests\Integration;
 
+use PHPUnit\Framework\TestCase;
 use WP_REST_Request;
 use WP_REST_Server;
-use WP_UnitTestCase;
 use WPDFV\Admin\Upgrades;
 use WPDFV\Includes\Reader;
 use WPDFV\Plugin;
@@ -17,7 +17,7 @@ use WPDFV\Plugin;
 /**
  * Covers WordPress contracts that the fast shim tests cannot prove.
  */
-class ReaderIntegrationTest extends WP_UnitTestCase {
+class ReaderIntegrationTest extends TestCase {
 	/**
 	 * REST server instance before the test.
 	 *
@@ -26,12 +26,26 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 	private $server;
 
 	/**
+	 * Post IDs created by the test.
+	 *
+	 * @var int[]
+	 */
+	private $post_ids = [];
+
+	/**
+	 * Site IDs created by the test.
+	 *
+	 * @var int[]
+	 */
+	private $site_ids = [];
+
+	/**
 	 * Set up WordPress REST routing for each test.
 	 *
 	 * @return void
 	 */
-	public function set_up() {
-		parent::set_up();
+	protected function setUp(): void {
+		parent::setUp();
 
 		$this->server              = isset( $GLOBALS['wp_rest_server'] ) ? $GLOBALS['wp_rest_server'] : null;
 		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
@@ -46,10 +60,22 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function tear_down() {
+	protected function tearDown(): void {
+		foreach ( $this->post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		foreach ( $this->site_ids as $site_id ) {
+			wp_delete_site( $site_id );
+		}
+
+		delete_option( 'wpdfv_settings' );
+		delete_option( 'wpdfv_version' );
+		delete_option( 'wpdfv_general' );
+		delete_option( 'wpdfv_upgrade_error' );
 		$GLOBALS['wp_rest_server'] = $this->server;
 
-		parent::tear_down();
+		parent::tearDown();
 	}
 
 	/**
@@ -70,7 +96,7 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_rest_content_returns_403_for_password_protected_post() {
-		$post_id = self::factory()->post->create(
+		$post_id = $this->create_post(
 			[
 				'post_status'   => 'publish',
 				'post_password' => 'secret',
@@ -89,7 +115,7 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_rest_content_returns_403_for_private_post() {
-		$post_id = self::factory()->post->create(
+		$post_id = $this->create_post(
 			[
 				'post_status' => 'private',
 			]
@@ -118,7 +144,7 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 			false
 		);
 
-		$post_id = self::factory()->post->create(
+		$post_id = $this->create_post(
 			[
 				'post_status' => 'publish',
 				'post_type'   => 'post',
@@ -137,7 +163,7 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_rest_content_returns_200_for_public_post() {
-		$post_id = self::factory()->post->create(
+		$post_id = $this->create_post(
 			[
 				'post_content' => '<p>Readable integration content.</p>',
 				'post_status'  => 'publish',
@@ -167,7 +193,7 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 		$this->assertSame( 'Reader Mode Toggle', $block->title );
 		$this->assertContains( 'postId', $block->uses_context );
 
-		$post_id = self::factory()->post->create(
+		$post_id = $this->create_post(
 			[
 				'post_status' => 'publish',
 			]
@@ -238,7 +264,7 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Run integration tests with WP_MULTISITE=1 to cover network activation.' );
 		}
 
-		$site_id = self::factory()->blog->create();
+		$site_id = $this->create_site();
 		delete_option( 'wpdfv_settings' );
 		delete_option( 'wpdfv_version' );
 
@@ -268,5 +294,66 @@ class ReaderIntegrationTest extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'GET', '/wp-distraction-free-view/v1/content/' . absint( $post_id ) );
 
 		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Create a WordPress post and track it for cleanup.
+	 *
+	 * @param array $args Post arguments.
+	 *
+	 * @return int
+	 */
+	private function create_post( array $args = [] ) {
+		$post_id = wp_insert_post(
+			array_merge(
+				[
+					'post_author'  => 1,
+					'post_content' => 'Reader content.',
+					'post_status'  => 'publish',
+					'post_title'   => 'Reader test post',
+					'post_type'    => 'post',
+				],
+				$args
+			),
+			true
+		);
+
+		$this->assertNotWPError( $post_id );
+		$this->post_ids[] = $post_id;
+
+		return $post_id;
+	}
+
+	/**
+	 * Create a multisite blog and track it for cleanup.
+	 *
+	 * @return int
+	 */
+	private function create_site() {
+		$site_id = wp_insert_site(
+			[
+				'domain' => 'site' . wp_rand( 1000, 9999 ) . '.example.org',
+				'path'   => '/',
+			]
+		);
+
+		$this->assertNotWPError( $site_id );
+		$this->site_ids[] = $site_id;
+
+		return $site_id;
+	}
+
+	/**
+	 * Assert a value is not a WP_Error instance.
+	 *
+	 * @param mixed $actual Value to inspect.
+	 *
+	 * @return void
+	 */
+	private function assertNotWPError( $actual ) {
+		$this->assertFalse(
+			is_wp_error( $actual ),
+			is_wp_error( $actual ) ? $actual->get_error_message() : 'Value is not a WP_Error.'
+		);
 	}
 }

--- a/tests/integration/ReaderIntegrationTest.php
+++ b/tests/integration/ReaderIntegrationTest.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Reader Mode WordPress integration tests.
+ *
+ * @package WPDistractionFreeView
+ */
+
+namespace WPDFV\Tests\Integration;
+
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+use WPDFV\Admin\Upgrades;
+use WPDFV\Includes\Reader;
+use WPDFV\Plugin;
+
+/**
+ * Covers WordPress contracts that the fast shim tests cannot prove.
+ */
+class ReaderIntegrationTest extends WP_UnitTestCase {
+	/**
+	 * REST server instance before the test.
+	 *
+	 * @var WP_REST_Server|null
+	 */
+	private $server;
+
+	/**
+	 * Set up WordPress REST routing for each test.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->server              = isset( $GLOBALS['wp_rest_server'] ) ? $GLOBALS['wp_rest_server'] : null;
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+
+		do_action( 'rest_api_init' );
+		update_option( 'wpdfv_settings', Reader::get_default_settings(), false );
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Restore REST server state.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		$GLOBALS['wp_rest_server'] = $this->server;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Missing posts return the public REST not-found contract.
+	 *
+	 * @return void
+	 */
+	public function test_rest_content_returns_404_for_missing_post() {
+		$response = $this->dispatch_content_request( 999999 );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'wpdfv_post_not_found', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Password-protected posts are not exposed through Reader Mode.
+	 *
+	 * @return void
+	 */
+	public function test_rest_content_returns_403_for_password_protected_post() {
+		$post_id = self::factory()->post->create(
+			[
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			]
+		);
+
+		$response = $this->dispatch_content_request( $post_id );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'wpdfv_post_forbidden', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Private posts are forbidden to anonymous readers.
+	 *
+	 * @return void
+	 */
+	public function test_rest_content_returns_403_for_private_post() {
+		$post_id = self::factory()->post->create(
+			[
+				'post_status' => 'private',
+			]
+		);
+
+		$response = $this->dispatch_content_request( $post_id );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'wpdfv_post_forbidden', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Disabled post types are not available through Reader Mode.
+	 *
+	 * @return void
+	 */
+	public function test_rest_content_returns_403_for_disabled_post_type() {
+		update_option(
+			'wpdfv_settings',
+			array_merge(
+				Reader::get_default_settings(),
+				[
+					'where_to_display' => [ 'page' ],
+				]
+			),
+			false
+		);
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			]
+		);
+
+		$response = $this->dispatch_content_request( $post_id );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'wpdfv_post_forbidden', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Public posts return rendered Reader Mode content.
+	 *
+	 * @return void
+	 */
+	public function test_rest_content_returns_200_for_public_post() {
+		$post_id = self::factory()->post->create(
+			[
+				'post_content' => '<p>Readable integration content.</p>',
+				'post_status'  => 'publish',
+				'post_title'   => 'Reader contract',
+			]
+		);
+
+		$response = $this->dispatch_content_request( $post_id );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $post_id, $data['id'] );
+		$this->assertStringContainsString( 'Readable integration content.', $data['content'] );
+		$this->assertArrayHasKey( 'readingTime', $data );
+	}
+
+	/**
+	 * The reader button block registers from block.json and renders from post context.
+	 *
+	 * @return void
+	 */
+	public function test_reader_button_block_registers_and_renders() {
+		$registry = \WP_Block_Type_Registry::get_instance();
+		$block    = $registry->get_registered( 'wpdfv/reader-button' );
+
+		$this->assertNotFalse( $block );
+		$this->assertSame( 'Reader Mode Toggle', $block->title );
+		$this->assertContains( 'postId', $block->uses_context );
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_status' => 'publish',
+			]
+		);
+
+		$markup = do_blocks(
+			sprintf(
+				'<!-- wp:query {"queryId":1,"query":{"perPage":1,"postType":"post","include":[%1$d]}} --><!-- wp:post-template --><!-- wp:wpdfv/reader-button {"buttonText":"Open Reader"} /--><!-- /wp:post-template --><!-- /wp:query -->',
+				$post_id
+			)
+		);
+
+		$this->assertStringContainsString( 'wpdfv-reader-toggle', $markup );
+		$this->assertStringContainsString( 'data-post-id="' . $post_id . '"', $markup );
+		$this->assertStringContainsString( 'Open Reader', $markup );
+	}
+
+	/**
+	 * Activation initializes fresh installs using real WordPress options.
+	 *
+	 * @return void
+	 */
+	public function test_activation_initializes_default_options() {
+		delete_option( 'wpdfv_settings' );
+		delete_option( 'wpdfv_version' );
+		delete_option( 'wpdfv_general' );
+
+		( new Plugin() )->activate();
+
+		$this->assertSame( WPDFV_VERSION, get_option( 'wpdfv_version' ) );
+		$this->assertSame( Reader::get_default_settings(), get_option( 'wpdfv_settings' ) );
+	}
+
+	/**
+	 * Legacy settings migrate through WordPress option APIs.
+	 *
+	 * @return void
+	 */
+	public function test_upgrade_migrates_legacy_options() {
+		update_option( 'wpdfv_version', '1.5.0', false );
+		update_option(
+			'wpdfv_general',
+			[
+				'display_read_mode_at' => 'before_content',
+				'read_mode_btn_text'   => 'Legacy button',
+			],
+			false
+		);
+
+		( new Upgrades() )->process_automatic_upgrades();
+
+		$settings = get_option( 'wpdfv_settings' );
+
+		$this->assertSame( WPDFV_VERSION, get_option( 'wpdfv_version' ) );
+		$this->assertSame( 'before_content', $settings['display_location'] );
+		$this->assertSame( 'Legacy button', $settings['button_text'] );
+	}
+
+	/**
+	 * Network activation initializes each site when the suite runs in multisite mode.
+	 *
+	 * @group ms-required
+	 *
+	 * @return void
+	 */
+	public function test_network_activation_initializes_each_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Run integration tests with WP_MULTISITE=1 to cover network activation.' );
+		}
+
+		$site_id = self::factory()->blog->create();
+		delete_option( 'wpdfv_settings' );
+		delete_option( 'wpdfv_version' );
+
+		switch_to_blog( $site_id );
+		delete_option( 'wpdfv_settings' );
+		delete_option( 'wpdfv_version' );
+		restore_current_blog();
+
+		( new Plugin() )->activate( true );
+
+		$this->assertSame( WPDFV_VERSION, get_option( 'wpdfv_version' ) );
+
+		switch_to_blog( $site_id );
+		$this->assertSame( WPDFV_VERSION, get_option( 'wpdfv_version' ) );
+		$this->assertSame( Reader::get_default_settings(), get_option( 'wpdfv_settings' ) );
+		restore_current_blog();
+	}
+
+	/**
+	 * Dispatch a Reader Mode content REST request.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch_content_request( $post_id ) {
+		$request = new WP_REST_Request( 'GET', '/wp-distraction-free-view/v1/content/' . absint( $post_id ) );
+
+		return rest_get_server()->dispatch( $request );
+	}
+}

--- a/tests/integration/bootstrap.php
+++ b/tests/integration/bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * WordPress integration test bootstrap.
+ *
+ * @package WPDistractionFreeView
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	fwrite( STDERR, "WordPress test suite not found. Run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest\n" );
+	exit( 1 );
+}
+
+require_once dirname( __DIR__, 2 ) . '/vendor/autoload.php';
+require_once $_tests_dir . '/includes/functions.php';
+
+tests_add_filter(
+	'muplugins_loaded',
+	static function () {
+		require dirname( __DIR__, 2 ) . '/wp-distraction-free-view.php';
+	}
+);
+
+require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
## Summary
- Adds a separate WordPress integration PHPUnit config and bootstrap while keeping the existing fast shim suite on composer test.
- Adds focused integration coverage for REST /content/<id> status contracts, block.json registration and dynamic rendering, activation defaults, legacy option migration, and multisite network activation when WP_MULTISITE=1.
- Wires a dedicated CI job with MySQL plus single-site and multisite integration runs, and documents local commands in README.

## Base branch
Base: release/1.8.0. This issue is in milestone 1.8.0 and the requested base branch is release/1.8.0, so this PR intentionally does not target main.

## Issue coverage
Refs #44.

Covered:
- REST missing, password-protected, private, disabled post type, and public post contracts.
- Reader button block registration from block.json and render behavior in a Query Loop-like context.
- Fresh activation and legacy migration against real WordPress options.
- Multisite network activation via WP_MULTISITE=1 integration run.

Deferred:
- No broad wp-env/browser harness was added for 1.8.0; the smallest durable layer here is WordPress PHPUnit integration coverage in CI.

## Validation
- composer validate --strict
- composer test
- vendor/bin/phpcs --standard=phpcs.ruleset.xml tests/integration/bootstrap.php tests/integration/ReaderIntegrationTest.php
- php -l tests/integration/bootstrap.php
- php -l tests/integration/ReaderIntegrationTest.php
- bash -n bin/install-wp-tests.sh
- git diff --check
- bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest

Integration command note: WP_TESTS_DIR="/var/folders/2n/rgb1t2952r15p8nrpj3tbbzm0000gn/T//wordpress-tests-lib" composer test:integration bootstrapped to the WordPress DB connection locally, but this machine has no MySQL listener on 127.0.0.1, so the full run is expected to execute in the new CI job with the MySQL service.