### PR TITLE
Cache normalized settings and catalog lookups per request

### DIFF
--- a/src/Admin/SettingsApi.php
+++ b/src/Admin/SettingsApi.php
@@ -36,6 +36,24 @@ class SettingsApi {
 	public $prefix = 'wpdfv';
 
 	/**
+	 * Public post type options cache for the current request.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var array|null
+	 */
+	protected $public_post_types_cache = null;
+
+	/**
+	 * Installed plugins cache for the current request.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var array|null
+	 */
+	protected $installed_plugins_cache = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0
@@ -248,6 +266,7 @@ class SettingsApi {
 		}
 
 		update_option( $this->get_settings_key(), $settings, false );
+		$this->invalidate_settings_request_cache();
 
 		return $this->get_settings_response();
 	}
@@ -299,6 +318,10 @@ class SettingsApi {
 	 * @return array
 	 */
 	protected function get_public_post_types() {
+		if ( null !== $this->public_post_types_cache ) {
+			return $this->public_post_types_cache;
+		}
+
 		$post_types = get_post_types( [ 'public' => true ], 'objects' );
 		$options    = [];
 
@@ -309,7 +332,9 @@ class SettingsApi {
 			];
 		}
 
-		return $options;
+		$this->public_post_types_cache = $options;
+
+		return $this->public_post_types_cache;
 	}
 
 	/**
@@ -530,6 +555,8 @@ class SettingsApi {
 			);
 		}
 
+		$this->invalidate_plugin_request_cache();
+
 		return true;
 	}
 
@@ -568,6 +595,8 @@ class SettingsApi {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+
+		$this->invalidate_plugin_request_cache();
 
 		return true;
 	}
@@ -624,13 +653,45 @@ class SettingsApi {
 	 * @return array
 	 */
 	protected function get_installed_plugins() {
+		if ( null !== $this->installed_plugins_cache ) {
+			return $this->installed_plugins_cache;
+		}
+
 		$this->load_plugin_admin_functions();
 
 		if ( ! function_exists( 'get_plugins' ) ) {
-			return [];
+			$this->installed_plugins_cache = [];
+
+			return $this->installed_plugins_cache;
 		}
 
-		return get_plugins();
+		$this->installed_plugins_cache = get_plugins();
+
+		return $this->installed_plugins_cache;
+	}
+
+	/**
+	 * Clear per-request settings caches after settings are saved.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return void
+	 */
+	protected function invalidate_settings_request_cache() {
+		$this->public_post_types_cache = null;
+		Reader::invalidate_request_cache();
+		Templates::invalidate_request_cache();
+	}
+
+	/**
+	 * Clear per-request plugin status caches after plugin actions.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return void
+	 */
+	protected function invalidate_plugin_request_cache() {
+		$this->installed_plugins_cache = null;
 	}
 
 	/**

--- a/src/Includes/Reader.php
+++ b/src/Includes/Reader.php
@@ -19,6 +19,24 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Reader {
 	/**
+	 * Normalized settings cache for the current request.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var array|null
+	 */
+	protected static $settings_cache = null;
+
+	/**
+	 * Public post type slugs cache for the current request.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var array|null
+	 */
+	protected static $public_post_type_slugs_cache = null;
+
+	/**
 	 * Maximum custom CSS length in bytes.
 	 *
 	 * @since 1.8.0
@@ -78,13 +96,31 @@ class Reader {
 	 * @return array
 	 */
 	public static function get_settings() {
+		if ( null !== self::$settings_cache ) {
+			return self::$settings_cache;
+		}
+
 		$settings = get_option( 'wpdfv_settings', [] );
 
 		if ( ! is_array( $settings ) ) {
 			$settings = [];
 		}
 
-		return self::sanitize_settings_data( array_merge( self::get_default_settings(), $settings ) );
+		self::$settings_cache = self::sanitize_settings_data( array_merge( self::get_default_settings(), $settings ) );
+
+		return self::$settings_cache;
+	}
+
+	/**
+	 * Clear per-request settings and catalog caches.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return void
+	 */
+	public static function invalidate_request_cache() {
+		self::$settings_cache               = null;
+		self::$public_post_type_slugs_cache = null;
 	}
 
 	/**
@@ -1083,10 +1119,18 @@ class Reader {
 	 * @return array
 	 */
 	protected static function get_public_post_type_slugs() {
-		if ( ! function_exists( 'get_post_types' ) ) {
-			return [ 'post', 'page' ];
+		if ( null !== self::$public_post_type_slugs_cache ) {
+			return self::$public_post_type_slugs_cache;
 		}
 
-		return array_keys( get_post_types( [ 'public' => true ], 'objects' ) );
+		if ( ! function_exists( 'get_post_types' ) ) {
+			self::$public_post_type_slugs_cache = [ 'post', 'page' ];
+
+			return self::$public_post_type_slugs_cache;
+		}
+
+		self::$public_post_type_slugs_cache = array_keys( get_post_types( [ 'public' => true ], 'objects' ) );
+
+		return self::$public_post_type_slugs_cache;
 	}
 }

--- a/src/Includes/Templates.php
+++ b/src/Includes/Templates.php
@@ -14,6 +14,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Templates {
 	/**
+	 * Registered template cache for the current request.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var array|null
+	 */
+	protected static $registered_templates_cache = null;
+
+	/**
+	 * Template options cache for the current request.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var array|null
+	 */
+	protected static $template_options_cache = null;
+
+	/**
 	 * Default modal template slug.
 	 *
 	 * @since 1.7.0
@@ -88,6 +106,10 @@ class Templates {
 	 * @return array
 	 */
 	public static function get_template_options() {
+		if ( null !== self::$template_options_cache ) {
+			return self::$template_options_cache;
+		}
+
 		$options = [];
 
 		foreach ( self::get_registered_templates() as $slug => $template ) {
@@ -98,7 +120,21 @@ class Templates {
 			];
 		}
 
-		return $options;
+		self::$template_options_cache = $options;
+
+		return self::$template_options_cache;
+	}
+
+	/**
+	 * Clear per-request modal template caches.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return void
+	 */
+	public static function invalidate_request_cache() {
+		self::$registered_templates_cache = null;
+		self::$template_options_cache     = null;
 	}
 
 	/**
@@ -186,6 +222,10 @@ class Templates {
 	 * @return array
 	 */
 	public static function get_registered_templates() {
+		if ( null !== self::$registered_templates_cache ) {
+			return self::$registered_templates_cache;
+		}
+
 		$templates = [
 			self::DEFAULT_TEMPLATE => [
 				'label'       => __( 'Default Reader Mode layout', 'wp-distraction-free-view' ),
@@ -207,7 +247,9 @@ class Templates {
 		 */
 		$templates = apply_filters( 'wpdfv_modal_templates', $templates );
 
-		return self::normalize_templates( $templates );
+		self::$registered_templates_cache = self::normalize_templates( $templates );
+
+		return self::$registered_templates_cache;
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -32,8 +32,25 @@ final class Plugin {
 		// Register services used throughout the plugin.
 		add_action( 'plugins_loaded', [ $this, 'register_services' ] );
 
+		// Clear request-level caches when settings change outside the Settings API.
+		add_action( 'add_option_wpdfv_settings', [ $this, 'invalidate_request_caches' ] );
+		add_action( 'update_option_wpdfv_settings', [ $this, 'invalidate_request_caches' ] );
+		add_action( 'delete_option_wpdfv_settings', [ $this, 'invalidate_request_caches' ] );
+
 		// Load text domain.
 		add_action( 'init', [ $this, 'load_plugin_textdomain' ] );
+	}
+
+	/**
+	 * Clears request-level caches affected by settings changes.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return void
+	 */
+	public function invalidate_request_caches() {
+		Includes\Reader::invalidate_request_cache();
+		Includes\Templates::invalidate_request_cache();
 	}
 
 	/**

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -108,6 +108,83 @@ class ReaderTest extends TestCase {
 	}
 
 	/**
+	 * Reader settings and public post type lookups are cached per request.
+	 *
+	 * @return void
+	 */
+	public function test_reader_settings_are_cached_per_request() {
+		\update_option(
+			'wpdfv_settings',
+			array_merge(
+				Reader::get_default_settings(),
+				[
+					'where_to_display' => [ 'post', 'book' ],
+				]
+			),
+			false
+		);
+
+		$this->assertSame( [ 'post', 'book' ], Reader::get_settings()['where_to_display'] );
+		$this->assertSame( [ 'post', 'book' ], Reader::where_to_display() );
+		$this->assertTrue( Reader::is_post_type_enabled( 'book' ) );
+		$this->assertSame( 1, $GLOBALS['wpdfv_test_get_post_types_calls'] );
+	}
+
+	/**
+	 * Settings update responses invalidate the cached normalized settings.
+	 *
+	 * @return void
+	 */
+	public function test_settings_update_invalidates_reader_settings_cache() {
+		\update_option(
+			'wpdfv_settings',
+			array_merge(
+				Reader::get_default_settings(),
+				[
+					'button_text' => 'Before cache',
+				]
+			),
+			false
+		);
+
+		$this->assertSame( 'Before cache', Reader::get_settings()['button_text'] );
+
+		$request = new \WP_REST_Request();
+		$request->set_param( 'button_text', 'After cache' );
+
+		( new TestableSettingsApi() )->update_settings_response( $request );
+
+		$this->assertSame( 'After cache', Reader::get_settings()['button_text'] );
+	}
+
+	/**
+	 * Template catalogs and options are cached per request.
+	 *
+	 * @return void
+	 */
+	public function test_template_options_are_cached_per_request() {
+		$template_filter_calls = 0;
+
+		\add_filter(
+			'wpdfv_modal_templates',
+			static function ( $templates ) use ( &$template_filter_calls ) {
+				++$template_filter_calls;
+				$templates['compact'] = [
+					'label'       => 'Compact',
+					'description' => 'Compact layout',
+					'content'     => '<!-- wp:post-title /-->',
+				];
+
+				return $templates;
+			}
+		);
+
+		$this->assertContains( 'compact', array_column( Templates::get_template_options(), 'value' ) );
+		$this->assertContains( 'compact', array_column( Templates::get_template_options(), 'value' ) );
+		$this->assertSame( 1, $template_filter_calls );
+	}
+
+	/**
 	 * Settings responses hide custom CSS from users without the CSS editing capability.
 	 *
 	 * @return void
@@ -781,6 +858,7 @@ class ReaderTest extends TestCase {
 		$this->assertSame( [ 'onecaptcha', 'themerouter' ], array_column( $plugins['paid'], 'slug' ) );
 		$this->assertSame( 'active', $plugins['free'][0]['status'] );
 		$this->assertSame( 'installed', $plugins['free'][1]['status'] );
+		$this->assertSame( 1, $GLOBALS['wpdfv_test_get_plugins_calls'] );
 	}
 
 	/**
@@ -820,5 +898,6 @@ class ReaderTest extends TestCase {
 		$this->assertTrue( $result );
 		$this->assertSame( [ 'cleanlinks/cleanlinks.php' ], $GLOBALS['wpdfv_test_active_plugins'] );
 		$this->assertSame( 'active', $plugins['free'][1]['status'] );
+		$this->assertSame( 2, $GLOBALS['wpdfv_test_get_plugins_calls'] );
 	}
 }

--- a/tests/TestableSettingsApi.php
+++ b/tests/TestableSettingsApi.php
@@ -23,6 +23,24 @@ class TestableSettingsApi extends SettingsApi {
 	}
 
 	/**
+	 * Expose public post type options.
+	 *
+	 * @return array
+	 */
+	public function get_public_post_types_for_tests() {
+		return $this->get_public_post_types();
+	}
+
+	/**
+	 * Expose installed plugin data.
+	 *
+	 * @return array
+	 */
+	public function get_installed_plugins_for_tests() {
+		return $this->get_installed_plugins();
+	}
+
+	/**
 	 * Activate a free companion plugin from the test catalog.
 	 *
 	 * @param string $slug Plugin slug.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,19 +10,21 @@
 
 define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 
-$GLOBALS['wpdfv_test_active_plugins'] = [];
-$GLOBALS['wpdfv_test_enqueued']       = [
+$GLOBALS['wpdfv_test_active_plugins']       = [];
+$GLOBALS['wpdfv_test_enqueued']             = [
 	'scripts'       => [],
 	'styles'        => [],
 	'inline'        => [],
 	'inline_styles' => [],
 ];
-$GLOBALS['wpdfv_test_options']        = [];
-$GLOBALS['wpdfv_test_filters']        = [];
-$GLOBALS['wpdfv_test_plugins']        = [];
-$GLOBALS['wpdfv_test_posts']          = [];
-$GLOBALS['wpdfv_test_shortcodes']     = [];
-$GLOBALS['wpdfv_test_user_caps']      = [];
+$GLOBALS['wpdfv_test_options']              = [];
+$GLOBALS['wpdfv_test_filters']              = [];
+$GLOBALS['wpdfv_test_get_plugins_calls']    = 0;
+$GLOBALS['wpdfv_test_get_post_types_calls'] = 0;
+$GLOBALS['wpdfv_test_plugins']              = [];
+$GLOBALS['wpdfv_test_posts']                = [];
+$GLOBALS['wpdfv_test_shortcodes']           = [];
+$GLOBALS['wpdfv_test_user_caps']            = [];
 
 if ( ! class_exists( 'WP_Post' ) ) {
 	class WP_Post {
@@ -61,25 +63,35 @@ require_once __DIR__ . '/shims/WP_REST_Request.php';
 require_once __DIR__ . '/shims/WP_REST_Response.php';
 
 function wpdfv_tests_reset_state() {
-	$GLOBALS['wpdfv_test_active_plugins'] = [];
-	$GLOBALS['wpdfv_test_enqueued']       = [
+	$GLOBALS['wpdfv_test_active_plugins']       = [];
+	$GLOBALS['wpdfv_test_enqueued']             = [
 		'scripts'       => [],
 		'styles'        => [],
 		'inline'        => [],
 		'inline_styles' => [],
 	];
-	$GLOBALS['wpdfv_test_options']        = [];
-	$GLOBALS['wpdfv_test_filters']        = [];
-	$GLOBALS['wpdfv_test_plugins']        = [];
-	$GLOBALS['wpdfv_test_posts']          = [];
-	$GLOBALS['wpdfv_test_shortcodes']     = [];
-	$GLOBALS['wpdfv_test_user_caps']      = [];
-	$_GET                                 = [];
+	$GLOBALS['wpdfv_test_options']              = [];
+	$GLOBALS['wpdfv_test_filters']              = [];
+	$GLOBALS['wpdfv_test_get_plugins_calls']    = 0;
+	$GLOBALS['wpdfv_test_get_post_types_calls'] = 0;
+	$GLOBALS['wpdfv_test_plugins']              = [];
+	$GLOBALS['wpdfv_test_posts']                = [];
+	$GLOBALS['wpdfv_test_shortcodes']           = [];
+	$GLOBALS['wpdfv_test_user_caps']            = [];
+	$_GET                                       = [];
 
 	if ( class_exists( '\WPDFV\Includes\Actions' ) ) {
 		$frontend_settings_added = new ReflectionProperty( '\WPDFV\Includes\Actions', 'frontend_settings_added' );
 		$frontend_settings_added->setAccessible( true );
 		$frontend_settings_added->setValue( null, false );
+	}
+
+	if ( class_exists( '\WPDFV\Includes\Reader' ) ) {
+		\WPDFV\Includes\Reader::invalidate_request_cache();
+	}
+
+	if ( class_exists( '\WPDFV\Includes\Templates' ) ) {
+		\WPDFV\Includes\Templates::invalidate_request_cache();
 	}
 }
 
@@ -194,6 +206,8 @@ function wp_json_encode( $value, $flags = 0, $depth = 512 ) {
 }
 
 function get_plugins() {
+	++$GLOBALS['wpdfv_test_get_plugins_calls'];
+
 	return $GLOBALS['wpdfv_test_plugins'];
 }
 
@@ -375,6 +389,8 @@ function number_format_i18n( $number ) {
 }
 
 function get_post_types( $args = [], $output = 'names' ) {
+	++$GLOBALS['wpdfv_test_get_post_types_calls'];
+
 	$post_types = [
 		'post' => (object) [
 			'name'   => 'post',


### PR DESCRIPTION
## Summary
- Cache normalized Reader settings and public post type slugs for the current request.
- Cache modal template catalogs/options and More Plugins installed-plugin lookups per request.
- Invalidate Reader/template caches after settings updates and installed-plugin caches after install/activate flows.

## Base Branch
- Base: `release/1.8.0`
- Reason: issue #45 is assigned to milestone `1.8.0`, and the release branch exists as `origin/release/1.8.0`.

## Scope
- Closes #45.
- Limited to per-request cache/performance improvements and focused unit coverage.
- No release, tag, package, frontend asset, or broad refactor work included.

## Validation
- `php -l src/Includes/Reader.php`
- `php -l src/Includes/Templates.php`
- `php -l src/Admin/SettingsApi.php`
- `php -l tests/ReaderTest.php`
- `php -l tests/TestableSettingsApi.php`
- `php -l tests/bootstrap.php`
- `composer test`
- `composer lint`
- `git diff --check`

## Release Notes
- No migration required.
- No frontend/admin asset build required; PHP-only behavior and test changes.
- Rollback is reverting this PR.
