### PR TITLE
Improve Reader Mode reading-time estimates

### DIFF
--- a/src/Includes/Reader.php
+++ b/src/Includes/Reader.php
@@ -506,7 +506,17 @@ class Reader {
 		$content = strip_shortcodes( (string) $content );
 		$content = function_exists( 'strip_blocks' ) ? strip_blocks( $content ) : preg_replace( '/<!--\s+\/?wp:.*?-->/s', ' ', $content );
 		$content = wp_strip_all_tags( html_entity_decode( $content, ENT_QUOTES, get_bloginfo( 'charset' ) ) );
-		$words   = str_word_count( $content );
+		$words   = self::count_reading_time_units( $content );
+
+		/**
+		 * Filter the content unit count used for Reader Mode estimates.
+		 *
+		 * @since 1.8.0
+		 *
+		 * @param int    $words   Counted readable content units.
+		 * @param string $content Plain text content used for the estimate.
+		 */
+		$words = absint( apply_filters( 'wpdfv_reading_time_word_count', $words, $content ) );
 
 		/**
 		 * Filter the words-per-minute value used for Reader Mode estimates.
@@ -519,6 +529,32 @@ class Reader {
 		$words_per_minute = $words_per_minute > 0 ? $words_per_minute : 200;
 
 		return max( 1, (int) ceil( $words / $words_per_minute ) );
+	}
+
+	/**
+	 * Count readable content units for reading-time estimates.
+	 *
+	 * Latin-like words are counted as words, while CJK characters are counted
+	 * individually so non-space-delimited content does not collapse to zero.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param string $content Plain text content.
+	 *
+	 * @return int
+	 */
+	protected static function count_reading_time_units( $content ) {
+		$content = trim( (string) $content );
+
+		if ( '' === $content ) {
+			return 0;
+		}
+
+		if ( preg_match_all( "/[\\p{Han}\\p{Hiragana}\\p{Katakana}\\p{Hangul}]|[\\p{L}\\p{N}]+(?:['’\\-][\\p{L}\\p{N}]+)*/u", $content, $matches ) ) {
+			return count( $matches[0] );
+		}
+
+		return str_word_count( $content );
 	}
 
 	/**

--- a/src/Includes/Shortcodes/Main.php
+++ b/src/Includes/Shortcodes/Main.php
@@ -126,7 +126,7 @@ class Main {
 		}
 
 		$prepared = Reader::prepare_rendered_content( Templates::render_modal_content( $post ), $post );
-		$minutes  = Reader::calculate_reading_time( $post->post_content );
+		$minutes  = Reader::calculate_reading_time( $prepared['content'] );
 
 		return rest_ensure_response(
 			[

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -297,6 +297,36 @@ class ReaderTest extends TestCase {
 	public function test_calculate_reading_time() {
 		$this->assertSame( 1, Reader::calculate_reading_time( '' ) );
 		$this->assertSame( 3, Reader::calculate_reading_time( str_repeat( 'word ', 401 ) ) );
+		$this->assertSame( 1, Reader::calculate_reading_time( 'Intro [gallery ids="1,2,3"] outro.' ) );
+		$this->assertSame( 1, Reader::calculate_reading_time( '<!-- wp:paragraph --><p>Rendered block text.</p><!-- /wp:paragraph -->' ) );
+		$this->assertSame( 3, Reader::calculate_reading_time( str_repeat( '読', 401 ) ) );
+	}
+
+	/**
+	 * Reading time filters remain backward compatible and can override counts.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_reading_time_filters() {
+		\add_filter(
+			'wpdfv_reading_time_words_per_minute',
+			static function () {
+				return 100;
+			}
+		);
+
+		$this->assertSame( 3, Reader::calculate_reading_time( str_repeat( 'word ', 201 ) ) );
+
+		\add_filter(
+			'wpdfv_reading_time_word_count',
+			static function ( $words, $content ) {
+				return false !== strpos( $content, 'override' ) ? 450 : $words;
+			},
+			10,
+			2
+		);
+
+		$this->assertSame( 5, Reader::calculate_reading_time( 'override' ) );
 	}
 
 	/**
@@ -432,10 +462,42 @@ class ReaderTest extends TestCase {
 
 		$this->assertStringContainsString( 'Readable content.', $data['content'] );
 		$this->assertSame( 'https://example.com/?p=42', $data['permalink'] );
+		$this->assertSame( 1, $data['readingTime']['minutes'] );
 		$this->assertStringNotContainsString( 'window.option_df_3751', $data['content'] );
 		$this->assertArrayHasKey( 'scripts', $data );
 		$this->assertCount( 1, $data['scripts'] );
 		$this->assertStringContainsString( 'window.option_df_3751', $data['scripts'][0]['content'] );
+	}
+
+	/**
+	 * REST content reading time uses rendered Reader content without another render pass.
+	 *
+	 * @return void
+	 */
+	public function test_reader_content_response_uses_rendered_content_for_reading_time() {
+		\update_option( 'wpdfv_settings', Reader::get_default_settings(), false );
+
+		$post               = new \WP_Post();
+		$post->ID           = 43;
+		$post->post_type    = 'post';
+		$post->post_content = 'Short source.';
+
+		$GLOBALS['wpdfv_test_posts'][43] = $post;
+
+		\add_filter(
+			'wpdfv_modal_template_content',
+			static function () {
+				return '<article><p>' . str_repeat( 'rendered ', 401 ) . '</p></article>';
+			}
+		);
+
+		$request = new \WP_REST_Request();
+		$request->set_param( 'id', 43 );
+
+		$response = ( new Main() )->get_content_response( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 3, $data['readingTime']['minutes'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary\n- Improve Reader Mode reading-time estimates with Unicode-aware content unit counting for CJK and other non-space-delimited content.\n- Calculate REST reading time from the already-rendered Reader Mode content so dynamic/template output is represented without rendering blocks a second time.\n- Add a filtered word-count hook while preserving the existing words-per-minute filter.\n\n## Issue\nCloses #46.\n\n## Validation\n- php -l src/Includes/Reader.php\n- php -l src/Includes/Shortcodes/Main.php\n- php -l tests/ReaderTest.php\n- composer test\n- composer lint\n- git diff --check\n\n## Risk\nLow-medium: reading-time estimates change for multilingual content and rendered Reader content, but labels and the existing words-per-minute filter remain compatible.