### PR TITLE
Fix Reader Mode content reliability

### DIFF
--- a/src/Includes/Reader.php
+++ b/src/Includes/Reader.php
@@ -1147,7 +1147,8 @@ class Reader {
 		}
 
 		$content = self::strip_script_text_residue_elements( $content, '#<(p|span)\b[^>]*>.*?</\1>#is', $patterns );
-		$content = self::strip_script_text_residue_elements( $content, '#<div\b[^>]*>(?:(?!</?div\b).)*</div>#is', $patterns );
+		$content = self::strip_script_text_residue_elements( $content, '#<div\b[^>]*>(?:(?!</?div\b).)*</div>#is', $patterns, 'div' );
+		$content = self::strip_script_text_residue_text_nodes( $content, $patterns );
 
 		return (string) preg_replace_callback(
 			'~(^|[\r\n])([^\r\n]*(?:window\.option_df_|window\.DFLIP|DFLIP\.parseBooks)[^\r\n]*)(?=[\r\n]|$)~i',
@@ -1168,16 +1169,62 @@ class Reader {
 	 * @since 1.7.1
 	 *
 	 * @param string   $content  Rendered modal template content.
-	 * @param string   $pattern  Element-matching regular expression.
+	 * @param string      $pattern      Element-matching regular expression.
+	 * @param string[]    $patterns     Regular expressions used to identify script residue.
+	 * @param string|null $element_name Matched element name, when the pattern does not capture it.
+	 *
+	 * @return string
+	 */
+	protected static function strip_script_text_residue_elements( $content, $pattern, array $patterns, $element_name = null ) {
+		return (string) preg_replace_callback(
+			$pattern,
+			static function ( $matches ) use ( $patterns, $element_name ) {
+				$tag_name = null !== $element_name ? (string) $element_name : strtolower( (string) ( $matches[1] ?? '' ) );
+
+				if ( 'div' === $tag_name && self::contains_reader_content_blocks( $matches[0] ) ) {
+					return $matches[0];
+				}
+
+				return self::looks_like_script_text_residue( $matches[0], $patterns ) ? '' : $matches[0];
+			},
+			$content
+		);
+	}
+
+	/**
+	 * Determine whether a wrapper contains normal reader content blocks.
+	 *
+	 * A rendered post-content div can also contain escaped embed setup text.
+	 * That residue should be removed, but the wrapper itself must remain.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param string $content Content fragment.
+	 *
+	 * @return bool
+	 */
+	protected static function contains_reader_content_blocks( $content ) {
+		return (bool) preg_match(
+			'#<(p|h[1-6]|blockquote|figure|figcaption|ul|ol|li|table|thead|tbody|tfoot|tr|td|th|hr|pre|code|article|section)\b#i',
+			(string) $content
+		);
+	}
+
+	/**
+	 * Strip standalone script residue that appears as text between elements.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param string   $content  Rendered modal template content.
 	 * @param string[] $patterns Regular expressions used to identify script residue.
 	 *
 	 * @return string
 	 */
-	protected static function strip_script_text_residue_elements( $content, $pattern, array $patterns ) {
+	protected static function strip_script_text_residue_text_nodes( $content, array $patterns ) {
 		return (string) preg_replace_callback(
-			$pattern,
+			'~(^|>)([^<>]*(?:window\.option_df_|window\.DFLIP|DFLIP\.parseBooks)[^<>]*)(?=<|$)~i',
 			static function ( $matches ) use ( $patterns ) {
-				return self::looks_like_script_text_residue( $matches[0], $patterns ) ? '' : $matches[0];
+				return self::looks_like_script_text_residue( $matches[2], $patterns ) ? $matches[1] : $matches[0];
 			},
 			$content
 		);

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -398,6 +398,22 @@ class ReaderTest extends TestCase {
 	}
 
 	/**
+	 * Reader content wrappers with mixed article text should not be stripped.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_rendered_content_preserves_mixed_reader_content_wrappers() {
+		$content = '<div class="wp-block-post-content"><p>First readable paragraph.</p>window.option_df_3751 = {"outline":[],"autoEnableOutline":"false"};<p>Second readable paragraph.</p></div>';
+		$result  = Reader::sanitize_rendered_content( $content );
+
+		$this->assertStringContainsString( '<div class="wp-block-post-content">', $result );
+		$this->assertStringContainsString( '<p>First readable paragraph.</p>', $result );
+		$this->assertStringContainsString( '<p>Second readable paragraph.</p>', $result );
+		$this->assertStringNotContainsString( 'window.option_df_3751', $result );
+		$this->assertStringNotContainsString( 'autoEnableOutline', $result );
+	}
+
+	/**
 	 * Prepared Reader Mode content returns shortcode scripts separately.
 	 *
 	 * @return void

--- a/tests/browser/reader-mode.spec.js
+++ b/tests/browser/reader-mode.spec.js
@@ -308,6 +308,40 @@ test.describe( 'Reader Mode smoke', () => {
 		);
 	} );
 
+	test( 'renders complete Reader REST content on desktop and mobile viewports', async ( {
+		page,
+	} ) => {
+		const content =
+			'<div class="wp-block-post-content">' +
+			'<p>First reliable reader paragraph.</p>' +
+			'<p>Final reliable reader paragraph.</p>' +
+			'</div>';
+
+		await mockReaderContentResponse( page, content );
+		await openReader( page );
+
+		await expect(
+			page.locator( `${ modalSelector } .wpdfv-reader-content` )
+		).toContainText( 'First reliable reader paragraph.' );
+		await expect(
+			page.locator( `${ modalSelector } .wpdfv-reader-content` )
+		).toContainText( 'Final reliable reader paragraph.' );
+
+		await page
+			.getByRole( 'button', { name: /exit reader mode|close/i } )
+			.click();
+		await page.setViewportSize( { width: 390, height: 844 } );
+		await mockReaderContentResponse( page, content );
+		await openReader( page );
+
+		await expect(
+			page.locator( `${ modalSelector } .wpdfv-reader-content` )
+		).toContainText( 'First reliable reader paragraph.' );
+		await expect(
+			page.locator( `${ modalSelector } .wpdfv-reader-content` )
+		).toContainText( 'Final reliable reader paragraph.' );
+	} );
+
 	test( 'keeps table of contents heading navigation keyboard accessible', async ( {
 		page,
 	} ) => {
@@ -647,6 +681,31 @@ async function getReaderPostId( page ) {
 async function waitForReaderContent( page ) {
 	await expect( page.locator( '.wpdfv-reader-loading' ) ).toHaveCount( 0 );
 	await expect( page.locator( '.wpdfv-reader-content' ) ).not.toBeEmpty();
+}
+
+async function mockReaderContentResponse( page, content ) {
+	await page.route(
+		'**/wp-json/wp-distraction-free-view/v1/content/**',
+		async ( route ) => {
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( {
+					id: 1,
+					title: 'Reliable Reader Fixture',
+					permalink:
+						'https://example.com/reliable-reader-fixture/',
+					content,
+					scripts: [],
+					toc: [],
+					readingTime: {
+						minutes: 1,
+						label: '1 min read',
+					},
+				} ),
+			} );
+		}
+	);
 }
 
 async function getReaderSourceUrl( page ) {


### PR DESCRIPTION
## Summary

- Fixes Reader Mode content preparation so a rendered post-content wrapper is not removed just because it contains standalone escaped script residue.
- Keeps standalone flipbook/script residue stripping intact, including bare text nodes between content blocks.
- Adds focused PHP coverage for the extraction/sanitization regression and a browser smoke guard for complete Reader REST content on desktop and mobile viewports.

## Reproduction and classification

- `https://metaphorspace.com/story-of-your-life/` exposes post `2754`; core WP REST returns rendered content around 120 KB, while the plugin Reader REST endpoint returned HTTP 200 with `contentLength: 0`.
- `https://metaphorspace.com/operating-instructions/` exposes post `2320`; plugin Reader REST returned content around 9.5 KB.
- Classification: REST content preparation / sanitization. The modal shell and mobile viewport are downstream; they only render the REST `content` payload.

## Scope

- Base: `release/1.8.0`, per issue #88 / milestone 1.8.0.
- Does not change #89 focus or keyboard behavior.
- Preserves #87/#90 constraints: close button tooltip source remains untouched, and modal accordion hydration remains untouched.

## Validation

- `php -l src/Includes/Reader.php` passed.
- `./vendor/bin/phpunit tests/ReaderTest.php --filter sanitize_rendered_content` passed: 6 tests, 25 assertions.
- `./vendor/bin/phpunit tests/ReaderTest.php` passed: 44 tests, 175 assertions.
- `composer lint` passed.
- `PATH=/Users/mehulgohil/.nvm/versions/node/v24.15.0/bin:$PATH npm run lint:js` passed.
- `PATH=/Users/mehulgohil/.nvm/versions/node/v24.15.0/bin:$PATH npm run build` passed.
- `PATH=/Users/mehulgohil/.nvm/versions/node/v24.15.0/bin:$PATH npm run test:browser -- tests/browser/reader-mode.spec.js` ran, but skipped all 17 tests because `WPDFV_SMOKE_BASE_URL` is not set.

## Browser proof status

- Automated browser proof is prepared in `tests/browser/reader-mode.spec.js`, including desktop and mobile content rendering from the Reader REST response.
- Local browser execution could not prove the final UI because the smoke base URL environment variable is missing.

## Known limitations

- The reporter site is still running its current deployed plugin version, so live URLs were used for classification only, not as proof of the branch after this fix.

Resolves #88.
