### PR TITLE
Stabilize Reader Mode browser smoke fixture

### DIFF
--- a/tests/browser/reader-mode.spec.js
+++ b/tests/browser/reader-mode.spec.js
@@ -163,11 +163,11 @@ test.describe( 'Reader Mode smoke', () => {
 	test( 'persists reader typography preferences', async ( {
 		page,
 	} ) => {
-		await page.addInitScript(
+		await page.goto( readerUrl );
+		await page.evaluate(
 			( key ) => window.localStorage.removeItem( key ),
 			storageKey
 		);
-		await page.goto( readerUrl );
 		await openReader( page );
 
 		await page.getByRole( 'button', { name: 'Reader settings' } ).click();
@@ -249,11 +249,12 @@ test.describe( 'Reader Mode smoke', () => {
 		page,
 	} ) => {
 		await page.setViewportSize( { width: 390, height: 844 } );
-		await page.addInitScript(
+		await mockReaderContentResponse( page, getTallReaderContent() );
+		await page.goto( readerUrl );
+		await page.evaluate(
 			( key ) => window.localStorage.removeItem( key ),
 			storageKey
 		);
-		await page.goto( readerUrl );
 		await openReader( page );
 
 		await page.getByRole( 'button', { name: 'Reader settings' } ).click();
@@ -530,6 +531,7 @@ test.describe( 'Reader Mode smoke', () => {
 		page,
 	} ) => {
 		await enableReaderResume( page );
+		await mockReaderContentResponse( page, getTallReaderContent() );
 		const postId = await getReaderPostId( page );
 
 		await page.evaluate(
@@ -559,6 +561,7 @@ test.describe( 'Reader Mode smoke', () => {
 		page,
 	} ) => {
 		await enableReaderResume( page );
+		await mockReaderContentResponse( page, getTallReaderContent() );
 		const postId = await getReaderPostId( page );
 
 		await page.evaluate(
@@ -685,7 +688,7 @@ async function openReader( page ) {
 	await page.locator( toggleSelector ).first().click();
 	await expect( page.locator( modalSelector ) ).toBeVisible();
 	await expect(
-		page.locator( '.wpdfv-reader-loading, .wpdfv-reader-content' )
+		page.locator( `${ modalSelector } .wpdfv-reader-content` )
 	).toBeVisible();
 }
 


### PR DESCRIPTION
## Summary

- Fixes the shared Reader Mode Playwright `openReader()` helper so it does not fail strict mode when both loading and content containers are present.
- Uses mocked tall Reader REST content for typography and resume/scroll persistence tests that should not depend on the local smoke post body.
- Keeps this test-only and scoped to issue #93 / 1.8.0 release-readiness browser proof.

## Base branch

Base: `release/1.8.0`.

## Scope

- Resolves #93.
- Test-only: `tests/browser/reader-mode.spec.js`.
- No production Reader Mode code changes.
- Does not alter #86/#88/#89 implementation behavior.

## Validation

- `WPDFV_SMOKE_BASE_URL=https://development.wp.local/wpdfv-post/ PATH=/Users/mehulgohil/.nvm/versions/node/v24.15.0/bin:$PATH npm run test:browser -- tests/browser/reader-mode.spec.js`
- Result: 18 passed, 1 skipped.
- Skip reason: configured Studio smoke page does not contain a core Accordion block, so the accordion-specific runtime proof still needs an accordion fixture page.

## Notes

The first sandboxed Playwright attempt failed to launch Chromium due macOS Mach port permissions. The successful validation above was run unsandboxed against the local WordPress Studio site.