### PR TITLE
Prepare 1.8.0 release metadata

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Define plugin version in SemVer format.
 if ( ! defined( 'WPDFV_VERSION' ) ) {
-	define( 'WPDFV_VERSION', '1.7.1' );
+	define( 'WPDFV_VERSION', '1.8.0' );
 }
 
 // Define plugin text domain.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-distraction-free-view",
-	"version": "1.7.1",
+	"version": "1.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-distraction-free-view",
-			"version": "1.7.1",
+			"version": "1.8.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-distraction-free-view",
-	"version": "1.7.1",
+	"version": "1.8.0",
 	"description": "Frontend Reader Mode and focused reading experience for WordPress content.",
 	"private": true,
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://buymeacoffee.com/mehulgohil
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 8.2
-Stable tag: 1.7.1
+Stable tag: 1.8.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -144,6 +144,14 @@ Yes. Existing saved settings remain in the `wpdfv_settings` option and old `wpdf
 
 == Changelog ==
 
+= 1.8.0 =
+- Added: Scoped Reader Mode custom CSS controls for administrators with the WordPress CSS editing capability.
+- Added: Reader Mode copy/share actions, local resume reading, table of contents navigation, reader-friendly print output, and expanded accessibility-focused typography controls.
+- Improved: Reader Mode content reliability for shortcode embeds and complex block output, including support-driven partial or empty content cases.
+- Improved: Reader Mode modal compatibility with WordPress core Accordion blocks and Interactivity API script modules.
+- Fixed: Reader Mode modal close button, initial keyboard focus, Escape close behavior, page-key scrolling, and tab order reliability.
+- Changed: Expanded browser smoke coverage for close behavior, focus, content completeness, accordion interaction, print, sharing, resume reading, and localStorage fallback handling.
+
 = 1.7.1 =
 - Fixed: Reader Mode content now strips complete script, style, and noscript blocks before final sanitization so shortcode embed configuration is not displayed as raw text.
 - Fixed: Updated the Reader Mode Toggle block metadata to Block API version 3 for current editor compatibility.
@@ -227,6 +235,9 @@ Yes. Existing saved settings remain in the `wpdfv_settings` option and old `wpdf
 - Ability to change "DF View" button text.
 
 == Upgrade Notice ==
+
+= 1.8.0 =
+Improves Reader Mode reliability, keyboard handling, core Accordion compatibility, content rendering, and browser validation while preserving WordPress 7.0 compatibility.
 
 = 1.7.1 =
 Improves Reader Mode compatibility with shortcode embeds that output inline scripts and hardens release/package validation.

--- a/wp-distraction-free-view.php
+++ b/wp-distraction-free-view.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Distraction Free View
  * Plugin URI: https://github.com/mehul0810/wp-distraction-free-view
  * Description: Adds a clean frontend Reader Mode to WordPress so visitors can focus on posts, pages, and selected public post types.
- * Version: 1.7.1
+ * Version: 1.8.0
  * Requires at least: 6.0
  * Requires PHP: 8.2
  * Author: Mehul Gohil


### PR DESCRIPTION
## Summary
- updates the plugin header, runtime version constant, readme stable tag, npm package metadata, and lockfile package version to `1.8.0`
- adds the `1.8.0` WordPress.org changelog and upgrade notice
- preserves `Tested up to: 7.0`, `Requires at least: 6.0`, and `Requires PHP: 8.2`

Fixes #95.

## Validation
- `php -l wp-distraction-free-view.php`
- `php -l config/constants.php`
- `composer validate --strict`
- `PATH=/Users/mehulgohil/.nvm/versions/node/v24.15.0/bin:$PATH npm run build`
- temporary no-dev production package shape: `.github/scripts/check-production-package.sh /private/tmp/wpdfv-release-95/build/wp-distraction-free-view`
- Plugin Check against throwaway installed production package copy: passed with existing warnings only (`load_plugin_textdomain`, restricted `wp` term in plugin name/slug)
- `WPDFV_SMOKE_BASE_URL=https://development.wp.local/wpdfv-accordion-smoke/ PATH=/Users/mehulgohil/.nvm/versions/node/v24.15.0/bin:$PATH npm run test:browser -- tests/browser/reader-mode.spec.js` => 19 passed

## Release scope
No production tag, GitHub release, WordPress.org publish, or beta release action.