### PR TITLE
Fix reader toggle leak in modal content

### DIFF
--- a/src/Includes/Reader.php
+++ b/src/Includes/Reader.php
@@ -617,6 +617,7 @@ class Reader {
 			$content = preg_replace( '#<(' . implode( '|', array_map( 'preg_quote', $tags ) ) . ')\b[^>]*>.*?</\1>#is', '', $content );
 		}
 
+		$content           = self::strip_reader_toggle_markup( $content );
 		$protected_samples = [];
 		$content           = self::protect_visible_code_samples( $content, $protected_samples );
 		$content           = self::strip_escaped_executable_blocks( $content, $tags );
@@ -644,6 +645,27 @@ class Reader {
 		 * @param \WP_Post|null $post Current post, when available.
 		 */
 		return (string) apply_filters( 'wpdfv_modal_content_after_kses', $content, $post );
+	}
+
+	/**
+	 * Remove WPDFV Reader Mode launch controls from rendered modal content.
+	 *
+	 * Manual shortcode and block placement should remain on the source page,
+	 * but the modal should never render another Reader Mode launch control
+	 * inside the reading surface.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param string $content Rendered modal template content.
+	 *
+	 * @return string
+	 */
+	protected static function strip_reader_toggle_markup( $content ) {
+		return (string) preg_replace(
+			'#<div\b[^>]*class=(["\'])[^"\']*\bwpdfv-fullscreen-container\b[^"\']*\1[^>]*>\s*<button\b[^>]*class=(["\'])[^"\']*\bwpdfv-reader-toggle\b[^"\']*\2[^>]*>.*?</button>\s*</div>#is',
+			'',
+			(string) $content
+		);
 	}
 
 	/**

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -414,6 +414,21 @@ class ReaderTest extends TestCase {
 	}
 
 	/**
+	 * Reader Mode strips its own launch control markup from rendered content.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_rendered_content_strips_reader_toggle_markup() {
+		$content = '<article><p>Before.</p><div class="wpdfv-fullscreen-container"><button type="button" class="wpdfv-fullscreen-btn wpdfv-reader-toggle" data-post-id="7" aria-haspopup="dialog" aria-label="Read in Reader Mode">Read in Reader Mode</button></div><p>After.</p></article>';
+		$result  = Reader::sanitize_rendered_content( $content );
+
+		$this->assertStringContainsString( '<p>Before.</p>', $result );
+		$this->assertStringContainsString( '<p>After.</p>', $result );
+		$this->assertStringNotContainsString( 'wpdfv-reader-toggle', $result );
+		$this->assertStringNotContainsString( 'Read in Reader Mode', $result );
+	}
+
+	/**
 	 * Prepared Reader Mode content returns shortcode scripts separately.
 	 *
 	 * @return void
@@ -431,6 +446,28 @@ class ReaderTest extends TestCase {
 		$this->assertSame( 'application/javascript', $prepared['scripts'][0]['attributes']['type'] );
 		$this->assertSame( '3751', $prepared['scripts'][0]['attributes']['data-book'] );
 		$this->assertStringContainsString( 'window.wpdfvScriptRan = true;', $prepared['scripts'][0]['content'] );
+	}
+
+	/**
+	 * RTL and Unicode-heavy content remains intact after Reader Mode preparation.
+	 *
+	 * @return void
+	 */
+	public function test_prepare_rendered_content_preserves_rtl_unicode_blocks() {
+		$content  = '<article><h2>«حالت مطالعه» برای WPDFV 1.8.0</h2><p dir="rtl" lang="fa">می‌خواهیم اعداد ۱۲۳۴۵۶۷۸۹۰، اعداد عربی ١٢٣٤٥٦٧٨٩٠، و ایموجی 👩‍💻 را ببینیم.</p><p dir="rtl" lang="fa">عبارت دارای اِعراب: السَّلَامُ عَلَيْكُمْ.</p><p dir="auto">Mixed LTR/RTL with https://development.wp.local/?reader-mode=1 and <code>wpdfv_reader_preferences</code>.</p><figure class="wp-block-table"><table><tbody><tr><td>۱</td><td>۱۲٬۳۴۵</td></tr></tbody></table></figure><figure class="wp-block-image"><img src="https://example.com/wp-content/plugins/wp-distraction-free-view/assets/dist/images/wpdfv-icon.png" alt="WPDFV fixture icon" /></figure><div class="wp-caption"><img src="https://example.com/wp-content/plugins/wp-distraction-free-view/assets/dist/images/wpdfv-icon.png" alt="نماد Reader Mode" /><p class="wp-caption-text">نماد Reader Mode با caption فارسی</p></div></article>';
+		$prepared = Reader::prepare_rendered_content( $content );
+
+		$this->assertStringContainsString( 'می‌خواهیم', $prepared['content'] );
+		$this->assertStringContainsString( '۱۲۳۴۵۶۷۸۹۰', $prepared['content'] );
+		$this->assertStringContainsString( '١٢٣٤٥٦٧٨٩٠', $prepared['content'] );
+		$this->assertStringContainsString( '👩‍💻', $prepared['content'] );
+		$this->assertStringContainsString( 'السَّلَامُ عَلَيْكُمْ', $prepared['content'] );
+		$this->assertStringContainsString( 'https://development.wp.local/?reader-mode=1', $prepared['content'] );
+		$this->assertStringContainsString( 'wp-caption-text', $prepared['content'] );
+		$this->assertStringContainsString( '<table>', $prepared['content'] );
+		$this->assertStringContainsString( '<img src="https://example.com/wp-content/plugins/wp-distraction-free-view/assets/dist/images/wpdfv-icon.png"', $prepared['content'] );
+		$this->assertNotEmpty( $prepared['toc'] );
+		$this->assertSame( '«حالت مطالعه» برای WPDFV 1.8.0', $prepared['toc'][0]['text'] );
 	}
 
 	/**

--- a/tests/browser/fixtures/provision-rtl-unicode-post.php
+++ b/tests/browser/fixtures/provision-rtl-unicode-post.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Provision a Studio fixture post for RTL and Unicode Reader Mode proof.
+ *
+ * @package WPDistractionFreeView
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 1 );
+}
+
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+$plugin_basename = 'wp-distraction-free-view/wp-distraction-free-view.php';
+
+if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin_basename ) && ! is_plugin_active( $plugin_basename ) ) {
+	activate_plugin( $plugin_basename );
+}
+
+if ( ! is_plugin_active( $plugin_basename ) || ! class_exists( '\WPDFV\Includes\Reader' ) ) {
+	fwrite( STDERR, "WP Distraction Free View must be active before provisioning the RTL fixture.\n" );
+	exit( 1 );
+}
+
+$settings = array_merge(
+	\WPDFV\Includes\Reader::get_default_settings(),
+	(array) get_option( 'wpdfv_settings', [] )
+);
+
+$settings['automatic_button_enabled'] = true;
+$settings['display_location']         = 'after_content';
+$settings['where_to_display']         = array_values(
+	array_unique(
+		array_merge(
+			(array) $settings['where_to_display'],
+			[ 'post' ]
+		)
+	)
+);
+
+update_option( 'wpdfv_settings', $settings, false );
+\WPDFV\Includes\Reader::invalidate_request_cache();
+
+$slug        = 'wpdfv-rtl-unicode-reader-fixture';
+$plugin_file = defined( 'WPDFV_PLUGIN_FILE' ) ? WPDFV_PLUGIN_FILE : WP_PLUGIN_DIR . '/' . $plugin_basename;
+$icon_url    = esc_url( plugins_url( 'assets/dist/images/wpdfv-icon.png', $plugin_file ) );
+$embed_slug  = 'wpdfv-rtl-unicode-embed-source';
+
+$embed_post = get_page_by_path( $embed_slug, OBJECT, 'post' );
+
+if ( ! $embed_post instanceof WP_Post ) {
+	$embed_post_id = wp_insert_post(
+		wp_slash(
+			[
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_title'   => 'WPDFV Embed Source',
+				'post_name'    => $embed_slug,
+				'post_content' => '<p>Embedded source for WPDFV Reader Mode RTL proof.</p>',
+			]
+		),
+		true
+	);
+
+	if ( is_wp_error( $embed_post_id ) ) {
+		fwrite( STDERR, $embed_post_id->get_error_message() . "\n" );
+		exit( 1 );
+	}
+
+	$embed_post = get_post( $embed_post_id );
+}
+
+$pattern_id = 0;
+
+if ( post_type_exists( 'wp_block' ) ) {
+	$pattern_existing = get_page_by_path( 'wpdfv-rtl-unicode-synced-pattern', OBJECT, 'wp_block' );
+	$pattern_content  = '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group"><!-- wp:paragraph --><p dir="rtl" lang="fa">الگوی همگام Reader Mode برای مقایسه‌ی محتوای همگام‌شده.</p><!-- /wp:paragraph --><!-- wp:list --><ul class="wp-block-list"><li>همگام ۱</li><li>همگام ۲</li></ul><!-- /wp:list --></div><!-- /wp:group -->';
+
+	if ( $pattern_existing instanceof WP_Post ) {
+		$pattern_id = wp_update_post(
+			wp_slash(
+				[
+					'ID'           => $pattern_existing->ID,
+					'post_content' => $pattern_content,
+				]
+			),
+			true
+		);
+	} else {
+		$pattern_id = wp_insert_post(
+			wp_slash(
+				[
+					'post_type'    => 'wp_block',
+					'post_status'  => 'publish',
+					'post_title'   => 'WPDFV RTL Unicode Synced Pattern',
+					'post_name'    => 'wpdfv-rtl-unicode-synced-pattern',
+					'post_content' => $pattern_content,
+				]
+			),
+			true
+		);
+	}
+
+	if ( is_wp_error( $pattern_id ) ) {
+		$pattern_id = 0;
+	}
+}
+
+$embed_url            = esc_url( get_permalink( $embed_post ) );
+$synced_pattern_block = $pattern_id > 0 ? sprintf( "\n<!-- wp:block {\"ref\":%d} /-->\n", $pattern_id ) : '';
+
+$content = sprintf(
+	<<<HTML
+<!-- wp:shortcode -->
+[wpdfv]
+<!-- /wp:shortcode -->
+
+<!-- wp:heading {"level":1} -->
+<h1 class="wp-block-heading">«حالت مطالعه» برای WPDFV 1.8.0</h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p dir="rtl" lang="fa">این پاراگراف فارسی برای بررسی Reader Mode ساخته شده است؛ می‌خواهیم اعداد فارسی ۱۲۳۴۵۶۷۸۹۰، اعداد عربی ١٢٣٤٥٦٧٨٩٠، نشانه‌های «، ؛ ؟»، نقل‌قول‌ها، و ایموجی 👩‍💻 🚀 را بدون به‌هم‌ریختگی ببینیم.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p dir="rtl" lang="fa">نمونه‌ی نیم‌فاصله: می‌نویسم و کتاب‌خانه. نمونه‌ی پیوند ZWJ: 👨‍👩‍👧‍👦. عبارت دارای اِعراب: السَّلَامُ عَلَيْكُمْ.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p dir="auto">Mixed LTR/RTL: نسخه WPDFV 1.8.0 در URL https://development.wp.local/?reader-mode=1 با quote "Reader Mode" و کد <code>wpdfv_reader_preferences</code> آزمایش می‌شود.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":2} -->
+<h2 class="wp-block-heading">زیرعنوان فارسی و English Mix</h2>
+<!-- /wp:heading -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:quote -->
+<blockquote class="wp-block-quote"><p dir="rtl" lang="fa">«خواندن متمرکز» باید متن ترکیبی RTL/LTR را سالم نگه دارد.</p></blockquote>
+<!-- /wp:quote --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p dir="auto">Nested block column with URL https://example.com/path?reader-mode=1 and quote “Reader Mode”.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><li>فهرست اول با نیم‌فاصله‌ی می‌خوانیم</li><li>Arabic digits: ١٢٣٤٥</li><li>Persian digits: ۱۲۳۴۵</li><li>Emoji sequence: 👩‍💻 👨‍👩‍👧‍👦</li></ul>
+<!-- /wp:list -->
+
+<!-- wp:table -->
+<figure class="wp-block-table"><table><thead><tr><th>ردیف</th><th>مقدار</th><th>LTR Note</th></tr></thead><tbody><tr><td>۱</td><td>۱۲٬۳۴۵</td><td>Build 1.8.0</td></tr><tr><td>٢</td><td>١٢٬٣٤٥</td><td>reader-mode=1</td></tr></tbody></table></figure>
+<!-- /wp:table -->
+
+<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="%1\$s" alt="WPDFV fixture icon" width="128" height="128" /></figure>
+<!-- /wp:image -->
+
+<!-- wp:shortcode -->
+[caption width="128"]<img src="%2\$s" alt="نماد Reader Mode" width="128" height="128" /> نماد Reader Mode با caption فارسی[/caption]
+<!-- /wp:shortcode -->
+
+<!-- wp:embed {"url":"%3\$s","type":"rich"} -->
+<figure class="wp-block-embed is-type-rich is-provider-wordpress wp-block-embed-wordpress"><div class="wp-block-embed__wrapper">
+%3\$s
+</div></figure>
+<!-- /wp:embed -->
+
+<!-- wp:code -->
+<pre class="wp-block-code"><code lang="text">const wpdfvFixture = "می‌خواهیم";
+const mixedSample = "Reader Mode 1.8.0";</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:preformatted -->
+<pre class="wp-block-preformatted">RTL preformatted: می‌خوانیم، ۱۲۳۴۵، ١٢٣٤٥، 👩‍💻</pre>
+<!-- /wp:preformatted -->
+%4\$s
+
+<!-- wp:paragraph -->
+<p dir="rtl" lang="fa">پاراگراف پایانی برای مقایسه‌ی بالا و پایین دکمه‌ها. اگر Reader Mode درست کار کند، همین متن باید در مودال و اسکرین‌شات موبایل و دسکتاپ دیده شود.</p>
+<!-- /wp:paragraph -->
+HTML,
+	$icon_url,
+	$icon_url,
+	$embed_url,
+	$synced_pattern_block
+);
+
+$existing = get_page_by_path( $slug, OBJECT, 'post' );
+$postarr  = [
+	'post_type'    => 'post',
+	'post_status'  => 'publish',
+	'post_title'   => 'WPDFV RTL Unicode Reader Fixture',
+	'post_name'    => $slug,
+	'post_content' => $content,
+];
+
+if ( $existing instanceof WP_Post ) {
+	$postarr['ID'] = $existing->ID;
+	$post_id       = wp_update_post( wp_slash( $postarr ), true );
+} else {
+	$post_id = wp_insert_post( wp_slash( $postarr ), true );
+}
+
+if ( is_wp_error( $post_id ) ) {
+	fwrite( STDERR, $post_id->get_error_message() . "\n" );
+	exit( 1 );
+}
+
+echo wp_json_encode(
+	[
+		'id'   => (int) $post_id,
+		'slug' => $slug,
+		'url'  => get_permalink( $post_id ),
+	]
+) . PHP_EOL;

--- a/tests/browser/reader-mode-rtl.spec.js
+++ b/tests/browser/reader-mode-rtl.spec.js
@@ -1,0 +1,135 @@
+const { expect, test } = require( '@playwright/test' );
+
+const fixtureUrl =
+	process.env.WPDFV_RTL_FIXTURE_URL ||
+	process.env.WPDFV_SMOKE_READER_PATH;
+const hasFixtureUrl = Boolean( fixtureUrl );
+const toggleSelector = '.wpdfv-fullscreen-btn.wpdfv-reader-toggle';
+const modalSelector = '.wpdfv-reader-modal';
+const requiredTexts = [
+	'می‌خواهیم',
+	'۱۲۳۴۵۶۷۸۹۰',
+	'١٢٣٤٥٦٧٨٩٠',
+	'السَّلَامُ عَلَيْكُمْ',
+	'https://development.wp.local/?reader-mode=1',
+	'نماد Reader Mode با caption فارسی',
+	'WPDFV Embed Source',
+	'const wpdfvFixture = "می‌خواهیم";',
+	'RTL preformatted: می‌خوانیم',
+];
+const optionalPatternText = 'الگوی همگام Reader Mode';
+const requiredSelectors = [
+	'.wpdfv-reader-content [dir="rtl"]',
+	'.wpdfv-reader-content .wp-block-heading',
+	'.wpdfv-reader-content .wp-block-group',
+	'.wpdfv-reader-content .wp-block-list',
+	'.wpdfv-reader-content .wp-block-table table',
+	'.wpdfv-reader-content .wp-block-image img',
+	'.wpdfv-reader-content .wp-caption img',
+	'.wpdfv-reader-content img.emoji[alt="👩‍💻"]',
+	'.wpdfv-reader-content img.emoji[alt="👨‍👩‍👧‍👦"]',
+	'.wpdfv-reader-content .wp-block-code code',
+	'.wpdfv-reader-content .wp-block-preformatted',
+];
+const viewports = [
+	{
+		name: 'desktop',
+		size: {
+			width: 1440,
+			height: 1600,
+		},
+	},
+	{
+		name: 'mobile',
+		size: {
+			width: 390,
+			height: 844,
+		},
+	},
+];
+
+test.describe( 'Reader Mode RTL fixture proof', () => {
+	test.skip(
+		! hasFixtureUrl,
+		'Set WPDFV_RTL_FIXTURE_URL to the provisioned Studio fixture URL.'
+	);
+
+	for ( const viewport of viewports ) {
+		test( `${ viewport.name } renders RTL and Unicode fixture content with top and bottom toggles`, async ( {
+			page,
+		}, testInfo ) => {
+			await page.setViewportSize( viewport.size );
+			await page.goto( fixtureUrl );
+
+			const toggles = page.locator( toggleSelector );
+			await expect( toggles ).toHaveCount( 2 );
+
+			const firstToggleBox = await toggles.nth( 0 ).boundingBox();
+			const secondToggleBox = await toggles.nth( 1 ).boundingBox();
+
+			expect( firstToggleBox ).not.toBeNull();
+			expect( secondToggleBox ).not.toBeNull();
+			expect( firstToggleBox.y ).toBeLessThan( secondToggleBox.y );
+
+			const readerResponsePromise = page.waitForResponse(
+				( response ) =>
+					response.url().includes(
+						'/wp-json/wp-distraction-free-view/v1/content/'
+					) && 'GET' === response.request().method()
+			);
+			await toggles.first().click();
+			const readerResponse = await readerResponsePromise;
+			const payload = await readerResponse.json();
+
+			expect( payload ).toMatchObject( {
+				id: expect.any( Number ),
+				title: expect.any( String ),
+				permalink: expect.any( String ),
+				content: expect.any( String ),
+				scripts: expect.any( Array ),
+				toc: expect.any( Array ),
+				readingTime: {
+					minutes: expect.any( Number ),
+					label: expect.any( String ),
+				},
+			} );
+			expect( payload.content ).toContain( 'می‌خواهیم' );
+			expect( payload.content ).toContain( '👩‍💻' );
+			expect( payload.content ).toContain( '👨‍👩‍👧‍👦' );
+			expect( payload.content ).toContain( 'نماد Reader Mode با caption فارسی' );
+			expect( payload.content ).toContain( 'RTL preformatted: می‌خوانیم' );
+
+			await expect( page.locator( modalSelector ) ).toBeVisible();
+			await expect( page.locator( '.wpdfv-reader-loading' ) ).toHaveCount(
+				0
+			);
+
+			const readerContent = page.locator(
+				`${ modalSelector } .wpdfv-reader-content`
+			);
+			await expect( readerContent ).toBeVisible();
+			await expect(
+				page.locator( `${ modalSelector } .wpdfv-reader-toggle` )
+			).toHaveCount( 0 );
+			await page.screenshot( {
+				fullPage: true,
+				path: testInfo.outputPath(
+					`reader-mode-rtl-${ viewport.name }-open.png`
+				),
+			} );
+
+			for ( const text of requiredTexts ) {
+				await expect( readerContent ).toContainText( text );
+			}
+
+			if ( payload.content.includes( optionalPatternText ) ) {
+				await expect( readerContent ).toContainText( optionalPatternText );
+			}
+
+			for ( const selector of requiredSelectors ) {
+				await expect( page.locator( selector ).first() ).toBeVisible();
+			}
+
+		} );
+	}
+} );


### PR DESCRIPTION
## Summary

- Strip WPDFV Reader Mode launch controls from rendered modal content so a manual `[wpdfv]` shortcode does not show another "Read in Reader Mode" button inside the modal.
- Add PHPUnit coverage for toggle-markup stripping and RTL/Unicode content preservation.
- Add a WPDFV-owned Studio/browser proof fixture for Farsi/RTL/Unicode content, top/bottom toggle placement, REST payload shape, and desktop/mobile modal rendering.

Implements #98.
Supports #88 and #97.

## Controlled Environment

- Studio site: `/private/tmp/wpdfv-proof-180`
- URL: `https://wpdfv-proof-180.local/`
- WordPress: `7.0.1-RC1`
- PHP: `8.2`
- Theme used for final automated proof: `twentytwentyfour`
- Plugin: local `release/1.8.0` checkout mounted into Studio as active `wp-distraction-free-view`
- Fixture URL: `https://wpdfv-proof-180.local/2026/07/06/wpdfv-rtl-unicode-reader-fixture/`

## Screenshot Proof

- Desktop after-fix: `/Users/mehulgohil/Studio/development/wp-content/plugins/wp-distraction-free-view/test-results/reader-mode-rtl-Reader-Mod-223cb-with-top-and-bottom-toggles-chromium/reader-mode-rtl-desktop-open.png`
- Mobile after-fix: `/Users/mehulgohil/Studio/development/wp-content/plugins/wp-distraction-free-view/test-results/reader-mode-rtl-Reader-Mod-37a0e-with-top-and-bottom-toggles-chromium/reader-mode-rtl-mobile-open.png`

## Validation

- `php -l src/Includes/Reader.php`
- `php -l tests/browser/fixtures/provision-rtl-unicode-post.php`
- `composer lint`
- `./vendor/bin/phpunit tests/ReaderTest.php`
- `studio wp --path /private/tmp/wpdfv-proof-180 eval-file /Users/mehulgohil/Studio/development/wp-content/plugins/wp-distraction-free-view/tests/browser/fixtures/provision-rtl-unicode-post.php`
- `WPDFV_RTL_FIXTURE_URL='https://wpdfv-proof-180.local/2026/07/06/wpdfv-rtl-unicode-reader-fixture/' /Users/mehulgohil/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node ./node_modules/.bin/playwright test tests/browser/reader-mode-rtl.spec.js --project=chromium`

## Notes

- The controlled proof preserves Farsi/RTL text, Persian/Arabic digits, zero-width joiner/non-joiner content, Arabic punctuation, diacritics, mixed LTR/RTL text, headings, lists, tables, images, captions, embeds, code/preformatted blocks, and synced pattern content.
- Emoji are preserved through the REST payload and rendered by WordPress as `img.emoji` nodes with the expected `alt` values, so the browser proof checks the rendered emoji image nodes instead of raw text extraction.
- No production release, issue closure, or public support reply is included.
