### PR TITLE
Fix RTL stylesheet loading

### DIFF
--- a/src/Admin/Actions.php
+++ b/src/Admin/Actions.php
@@ -53,6 +53,7 @@ class Actions {
 			[ 'wp-components' ],
 			$asset['version']
 		);
+		wp_style_add_data( 'wpdfv-admin', 'rtl', 'replace' );
 
 		wp_enqueue_script(
 			'wpdfv-admin',

--- a/src/Includes/Actions.php
+++ b/src/Includes/Actions.php
@@ -68,6 +68,7 @@ class Actions {
 			[],
 			$asset['version']
 		);
+		wp_style_add_data( 'wpdfv-core', 'rtl', 'replace' );
 
 		wp_register_script(
 			'wpdfv-core',

--- a/tests/ActionsTest.php
+++ b/tests/ActionsTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Asset action tests.
+ *
+ * @package WPDistractionFreeView
+ */
+
+namespace WPDFV\Tests;
+
+use PHPUnit\Framework\TestCase;
+use WPDFV\Admin\Actions as AdminActions;
+use WPDFV\Includes\Actions as FrontendActions;
+
+/**
+ * Tests for frontend and admin asset registration.
+ */
+class ActionsTest extends TestCase {
+	/**
+	 * Reset test state.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		\wpdfv_tests_reset_state();
+	}
+
+	/**
+	 * Frontend styles opt into WordPress RTL replacement.
+	 *
+	 * @return void
+	 */
+	public function test_frontend_style_uses_rtl_replacement() {
+		FrontendActions::register_frontend_assets();
+
+		$this->assertSame( 'replace', $GLOBALS['wpdfv_test_enqueued']['style_data']['wpdfv-core']['rtl'] );
+	}
+
+	/**
+	 * Admin styles opt into WordPress RTL replacement.
+	 *
+	 * @return void
+	 */
+	public function test_admin_style_uses_rtl_replacement() {
+		$actions = new AdminActions();
+
+		$actions->register_admin_assets( 'settings_page_wpdfv_settings' );
+
+		$this->assertSame( 'replace', $GLOBALS['wpdfv_test_enqueued']['style_data']['wpdfv-admin']['rtl'] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,7 @@ $GLOBALS['wpdfv_test_active_plugins']       = [];
 $GLOBALS['wpdfv_test_enqueued']             = [
 	'scripts'       => [],
 	'styles'        => [],
+	'style_data'    => [],
 	'inline'        => [],
 	'inline_styles' => [],
 ];
@@ -67,6 +68,7 @@ function wpdfv_tests_reset_state() {
 	$GLOBALS['wpdfv_test_enqueued']             = [
 		'scripts'       => [],
 		'styles'        => [],
+		'style_data'    => [],
 		'inline'        => [],
 		'inline_styles' => [],
 	];
@@ -175,6 +177,12 @@ function wp_enqueue_style( $handle, $src = '', $deps = [], $ver = false, $media 
 	return true;
 }
 
+function wp_style_add_data( $handle, $key, $value ) {
+	$GLOBALS['wpdfv_test_enqueued']['style_data'][ $handle ][ $key ] = $value;
+
+	return true;
+}
+
 function wp_register_script( $handle, $src = '', $deps = [], $ver = false, $args = [] ) {
 	return true;
 }
@@ -199,6 +207,10 @@ function wp_add_inline_style( $handle, $data ) {
 	$GLOBALS['wpdfv_test_enqueued']['inline_styles'][ $handle ][] = $data;
 
 	return true;
+}
+
+function wp_enqueue_code_editor( $settings ) {
+	return [];
 }
 
 function wp_json_encode( $value, $flags = 0, $depth = 512 ) {
@@ -415,6 +427,7 @@ require_once dirname( __DIR__ ) . '/src/Includes/Reader.php';
 require_once dirname( __DIR__ ) . '/src/Includes/Helpers.php';
 require_once dirname( __DIR__ ) . '/src/Includes/Actions.php';
 require_once dirname( __DIR__ ) . '/src/Includes/Blocks.php';
+require_once dirname( __DIR__ ) . '/src/Admin/Actions.php';
 require_once dirname( __DIR__ ) . '/src/Admin/Upgrades.php';
 require_once dirname( __DIR__ ) . '/src/Admin/SettingsApi.php';
 require_once dirname( __DIR__ ) . '/src/Includes/Shortcodes/Main.php';


### PR DESCRIPTION
## Summary

Fixes #104.
Supports the controlled RTL/Farsi proof work in #88 and #97.

WordPress already builds and serves the generated WPDFV RTL bundles, but the `wpdfv-core` and `wpdfv-admin` style handles did not opt into the standard RTL replacement contract. Actual RTL locales therefore received the LTR CSS.

## Changes

- Mark `wpdfv-core` with `wp_style_add_data( 'wpdfv-core', 'rtl', 'replace' )`.
- Mark `wpdfv-admin` with `wp_style_add_data( 'wpdfv-admin', 'rtl', 'replace' )`.
- Add focused PHPUnit coverage for both handles.
- Leave CSS, extraction/sanitization, REST payloads, UI copy, and release metadata unchanged.

## Controlled browser proof

Same dedicated local environment before and after:

- WordPress: 7.0.1
- PHP: 8.2.31
- Plugin code: `release/1.8.1` plus this PR
- Theme: Twenty Twenty-Five 1.5
- Locale: `fa_IR`; `<html dir="rtl" lang="fa-IR">`
- Browser: Playwright Chromium 148.0.7778.96
- Frontend desktop: 1440x1000
- Admin desktop: 1280x720
- Mobile: 390x844

Observed before:

- Frontend loaded `assets/dist/wpdfv.css`.
- Admin loaded `assets/dist/wpdfv-admin.css`.
- Floating toggle was on the right: left 1150.9 / right 1401 at 1440px.
- Reader settings drawer opened from the right: left 1080 / right 1440, left border.
- Admin document overflowed horizontally by 20px: client 1265 / scroll 1285.

Observed after:

- Frontend loads `assets/dist/wpdfv-rtl.css`.
- Admin loads `assets/dist/wpdfv-admin-rtl.css`.
- Floating toggle moves to the left: left 24 / right 274.1.
- Reader settings drawer opens from the left: left 0 / right 360, right border.
- Admin overflow is removed: client 1265 / scroll 1265.
- Mixed Farsi/RTL/Unicode fixture content and Reader REST payload remain intact.
- No frontend or admin console/runtime errors were recorded; Reader REST response completed successfully.

Proof paths in the clean worktree:

- Before: `artifacts/rtl-proof/before/`
- After: `artifacts/rtl-proof/after/`
- Mobile after-proof: `test-results/reader-mode-rtl-Reader-Mod-37a0e-with-top-and-bottom-toggles-chromium/reader-mode-rtl-mobile-open.png`
- Desktop after-proof: `test-results/reader-mode-rtl-Reader-Mod-223cb-with-top-and-bottom-toggles-chromium/reader-mode-rtl-desktop-open.png`

The GitHub connector available to this task does not expose binary attachment upload, so the screenshots could not be attached to the PR. The local files above are retained and were visually inspected. The block-editor shell also proved the same RTL handle switch, but its canvas remained blank in the in-app browser; per the scoped change, frontend/admin and automated mobile proof are the release evidence.

## Validation

- `./vendor/bin/phpunit --filter ActionsTest`: 2 tests, 2 assertions
- `composer test`: 48 tests, 192 assertions
- `composer lint`: pass
- `composer validate --strict`: pass
- `php -l src/Includes/Actions.php`: pass
- `php -l src/Admin/Actions.php`: pass
- `npm run lint:js`: pass
- `npm run lint:css`: pass
- `npm run build`: pass; both RTL bundles emitted
- `WPDFV_RTL_FIXTURE_URL=http://localhost:8899/wpdfv-rtl-unicode-reader-fixture/ npx playwright test tests/browser/reader-mode-rtl.spec.js --project=chromium`: 2 passed
- `git diff --check`: pass

The separate WordPress integration suite was not run because `/tmp/wordpress-tests-lib` is absent in this environment. Runtime proof used the dedicated real WordPress 7.0.1 site instead.

## Risk

Low to medium. This uses WordPress's normal RTL stylesheet replacement contract and keeps LTR URLs and assets unchanged. It affects frontend, editor-shared, and admin style selection only.

## Gates

No merge, tag, release, WordPress.org publish, issue closure, milestone retarget, or public support reply is part of this PR.