### PR TITLE
Fix subpackage docblock typo in uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -5,7 +5,7 @@
  * @since 1.4.2
  *
  * @package    WordPress
- * @subpackage WP Distration Free View
+ * @subpackage WP Distraction Free View
  * @author     Mehul Gohil <hello@mehulgohil.com>
  */
 


### PR DESCRIPTION
## Summary
- `uninstall.php`'s file header read `@subpackage WP Distration Free View` — corrected to `WP Distraction Free View`.

## Test Plan
- [x] `php -l uninstall.php`
- [x] `composer lint` (PHPCS/WPCS) — 0 violations
- [x] Visual diff review — comment-only change, no executable code affected