### PR TITLE
chore: prepare 1.8.2 compatibility metadata for WordPress 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ WordPress core already includes distraction-free writing tools for the admin edi
 ## Requirements
 
 - WordPress 6.0 or later
-- Tested up to WordPress 7.0
+- Tested up to WordPress 7.1
 - PHP 8.2 or later
 - Node.js 24.15.0
 - npm 11 or later

--- a/config/constants.php
+++ b/config/constants.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Define plugin version in SemVer format.
 if ( ! defined( 'WPDFV_VERSION' ) ) {
-	define( 'WPDFV_VERSION', '1.8.1' );
+	define( 'WPDFV_VERSION', '1.8.2' );
 }
 
 // Define plugin text domain.

--- a/languages/wpdfv.pot
+++ b/languages/wpdfv.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL-2.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Distraction Free View 1.7.1\n"
+"Project-Id-Version: WP Distraction Free View 1.8.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-distraction-free-view\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-distraction-free-view",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-distraction-free-view",
-			"version": "1.8.1",
+			"version": "1.8.2",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-distraction-free-view",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"description": "Frontend Reader Mode and focused reading experience for WordPress content.",
 	"private": true,
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: mehul0810
 Tags: reader mode, reading mode, distraction free, focused reading, accessibility
 Donate link: https://buymeacoffee.com/mehulgohil
 Requires at least: 6.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 8.2
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -70,7 +70,7 @@ Reader Mode can also open from the URL on enabled single content:
 
 Setup and troubleshooting guide:
 
-https://github.com/mehul0810/wp-distraction-free-view/blob/release/1.8.1/docs/reader-mode-setup.md
+https://github.com/mehul0810/wp-distraction-free-view/blob/release/1.8.2/docs/reader-mode-setup.md
 
 = Template Customization =
 
@@ -143,6 +143,9 @@ Yes. Existing saved settings remain in the `wpdfv_settings` option and old `wpdf
 3. Reader Mode modal with reading time, print/fullscreen controls, and the Reader settings side panel.
 
 == Changelog ==
+
+= 1.8.2 =
+- Tested: Validated installation, activation, Reader Mode content REST responses, shortcode registration, editor block registration, and RTL/unicode content handling against WordPress 7.1. [#125](https://github.com/mehul0810/wp-distraction-free-view/issues/125)
 
 = 1.8.1 =
 - Fixed: Reader Mode launch controls no longer leak into rendered modal content when manual toggles are present. [#99](https://github.com/mehul0810/wp-distraction-free-view/pull/99)
@@ -239,6 +242,9 @@ Yes. Existing saved settings remain in the `wpdfv_settings` option and old `wpdf
 - Ability to change "DF View" button text.
 
 == Upgrade Notice ==
+
+= 1.8.2 =
+Validated compatibility with WordPress 7.1, including the packaged plugin runtime, Reader Mode content endpoint, settings route registration, shortcode, editor block, and RTL/unicode content handling.
 
 = 1.8.1 =
 Prevents Reader Mode toggles from leaking into modal content and ensures frontend and admin RTL stylesheets load for RTL locales.

--- a/tests/ReleaseMetadataTest.php
+++ b/tests/ReleaseMetadataTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Release metadata synchronization tests.
+ *
+ * @package WPDistractionFreeView
+ */
+
+namespace WPDFV\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ensures packaged release identifiers remain synchronized.
+ */
+class ReleaseMetadataTest extends TestCase {
+	/**
+	 * All release metadata files use the same version.
+	 *
+	 * @return void
+	 */
+	public function test_release_metadata_versions_are_synchronized() {
+		$root = dirname( __DIR__ );
+
+		$plugin_header = $this->read_file( $root . '/wp-distraction-free-view.php' );
+		$constants     = $this->read_file( $root . '/config/constants.php' );
+		$package       = json_decode( $this->read_file( $root . '/package.json' ), true, 512, JSON_THROW_ON_ERROR );
+		$package_lock  = json_decode( $this->read_file( $root . '/package-lock.json' ), true, 512, JSON_THROW_ON_ERROR );
+		$readme        = $this->read_file( $root . '/readme.txt' );
+		$pot           = $this->read_file( $root . '/languages/wpdfv.pot' );
+
+		preg_match( '/^\s*\* Version:\s*(\S+)/m', $plugin_header, $plugin_match );
+		preg_match( "/define\(\s*'WPDFV_VERSION',\s*'([^']+)'/", $constants, $constant_match );
+		preg_match( '/^Stable tag:\s*(\S+)/m', $readme, $stable_tag_match );
+		preg_match( '/Project-Id-Version: WP Distraction Free View ([^"\\\\]+)/', $pot, $pot_match );
+
+		$versions = [
+			'plugin header' => $plugin_match[1] ?? null,
+			'constant'      => $constant_match[1] ?? null,
+			'package'       => $package['version'] ?? null,
+			'package lock'  => $package_lock['version'] ?? null,
+			'lock root'     => $package_lock['packages']['']['version'] ?? null,
+			'stable tag'    => $stable_tag_match[1] ?? null,
+			'pot'           => $pot_match[1] ?? null,
+		];
+
+		$this->assertSame( '1.8.2', $versions['plugin header'] );
+		$this->assertSame( 1, count( array_unique( $versions ) ), print_r( $versions, true ) );
+	}
+
+	/**
+	 * Read a required release metadata file.
+	 *
+	 * @param string $path File path.
+	 * @return string
+	 */
+	private function read_file( $path ) {
+		$contents = file_get_contents( $path );
+		$this->assertIsString( $contents );
+
+		return $contents;
+	}
+}

--- a/wp-distraction-free-view.php
+++ b/wp-distraction-free-view.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Distraction Free View
  * Plugin URI: https://github.com/mehul0810/wp-distraction-free-view
  * Description: Adds a clean frontend Reader Mode to WordPress so visitors can focus on posts, pages, and selected public post types.
- * Version: 1.8.1
+ * Version: 1.8.2
  * Requires at least: 6.0
  * Requires PHP: 8.2
  * Author: Mehul Gohil


### PR DESCRIPTION
## Summary

- Prepare the 1.8.2 plugin metadata and documentation for the WordPress 7.1 compatibility validation in #125.
- Update the plugin/package version to 1.8.2 and `Tested up to` to 7.1.
- Record the bounded WordPress 7.1 runtime evidence and 1.8.2 release notes.
- Keep the packaged POT identity synchronized at 1.8.2 and add a focused metadata regression test.

## Validation

- `composer validate --strict`
- `composer lint`
- `composer test` (49 tests, 200 assertions)
- `npm ci`
- `npm run lint:js`
- `npm run lint:css`
- `npm run build`
- `git diff --check`
- `bash .github/scripts/check-production-package.sh build/wp-distraction-free-view`
- Production ZIP built from `.distignore` and inspected for 1.8.2/7.1 metadata.
- Packaged POT verified with `Project-Id-Version: WP Distraction Free View 1.8.2`.

## WordPress 7.1 evidence

- Isolated `@wp-playground/cli` server: WordPress 7.1, PHP 8.3.32, existing worktree mounted.
- Homepage and REST index returned HTTP 200.
- `/wp-json/wp-distraction-free-view/v1/content/1` returned HTTP 200 with Reader content and reading-time JSON.
- Process probe confirmed plugin activation, `[wpdfv]` shortcode registration, `wpdfv/reader-button` block registration, settings/content route registration, and content response status 200.
- Existing PHPUnit coverage includes RTL/unicode Reader content and generated RTL asset output was rebuilt.
- Plugin Check is not installed locally; the repository production-package Plugin Check action remains for hosted CI.

Refs #125
